### PR TITLE
 test: 테스트 환경을 위한 초기 세팅 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.0.5'
 	id 'io.spring.dependency-management' version '1.1.0'
-//	id 'org.asciidoctor.convert' version '2.2.1'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.kusitms'
@@ -13,6 +13,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	asciidoctorExtensions
 }
 
 repositories {
@@ -31,15 +32,33 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	outputs.dir snippetsDir
 }
 
-//tasks.named('asciidoctor') {
-//	inputs.dir snippetsDir
-//	dependsOn test
-//}
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+asciidoctor {
+	configurations 'asciidoctorExtensions'
+	inputs.dir snippetsDir
+	dependsOn test
+}
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+bootJar {
+	dependsOn copyDocument // 9
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,7 @@ spring:
         format_sql: true
         show_sql: true
         hbm2ddl:
-          auto:
-            auto: create
+          auto: create
 
 logging:
   level:

--- a/src/test/java/com/kusitms/wannafly/WannaflyApplicationTests.java
+++ b/src/test/java/com/kusitms/wannafly/WannaflyApplicationTests.java
@@ -1,9 +1,12 @@
 package com.kusitms.wannafly;
 
+import com.kusitms.wannafly.support.WannaflyTestIsolationExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ExtendWith(WannaflyTestIsolationExtension.class)
 class WannaflyApplicationTests {
 
 	@Test

--- a/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
+++ b/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
@@ -1,0 +1,54 @@
+package com.kusitms.wannafly.support;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class WannaflyDatabaseManager {
+    private final EntityManager entityManager;
+    private final List<String> tableNames;
+
+    public WannaflyDatabaseManager(EntityManager entityManager) {
+        this.entityManager = entityManager;
+        this.tableNames = extractTableNames(entityManager);
+    }
+
+    private List<String> extractTableNames(EntityManager entityManager) {
+        return entityManager.getMetamodel().getEntities().stream()
+                .filter(this::isEntity)
+                .map(this::convertCamelToSnake)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isEntity(EntityType<?> entityType) {
+        return entityType.getJavaType().getAnnotation(Entity.class) != null;
+    }
+
+    private String convertCamelToSnake(EntityType<?> entityType) {
+        String regex = "([a-z])([A-Z]+)";
+        String replacement = "$1_$2";
+        return entityType.getName()
+                .replaceAll(regex, replacement)
+                .toUpperCase();
+    }
+
+    @Transactional
+    public void truncateTables() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery(
+                    "ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_ID" + " RESTART WITH 1"
+            ).executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
+++ b/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
@@ -3,8 +3,6 @@ package com.kusitms.wannafly.support;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.EntityType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
+++ b/src/test/java/com/kusitms/wannafly/support/WannaflyDatabaseManager.java
@@ -45,9 +45,6 @@ public class WannaflyDatabaseManager {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery(
-                    "ALTER TABLE " + tableName + " ALTER COLUMN " + tableName + "_ID" + " RESTART WITH 1"
-            ).executeUpdate();
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }

--- a/src/test/java/com/kusitms/wannafly/support/WannaflyTestIsolationExtension.java
+++ b/src/test/java/com/kusitms/wannafly/support/WannaflyTestIsolationExtension.java
@@ -1,0 +1,19 @@
+package com.kusitms.wannafly.support;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class WannaflyTestIsolationExtension implements AfterEachCallback  {
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        WannaflyDatabaseManager databaseManager = getWannaflyDatabaseManager(context);
+        databaseManager.truncateTables();
+    }
+
+    private WannaflyDatabaseManager getWannaflyDatabaseManager(ExtensionContext context) {
+        return (WannaflyDatabaseManager) SpringExtension
+                .getApplicationContext(context).getBean("wannaflyDatabaseManager");
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/support/WannaflyTestIsolationExtension.java
+++ b/src/test/java/com/kusitms/wannafly/support/WannaflyTestIsolationExtension.java
@@ -14,6 +14,7 @@ public class WannaflyTestIsolationExtension implements AfterEachCallback  {
 
     private WannaflyDatabaseManager getWannaflyDatabaseManager(ExtensionContext context) {
         return (WannaflyDatabaseManager) SpringExtension
-                .getApplicationContext(context).getBean("wannaflyDatabaseManager");
+                .getApplicationContext(context)
+                .getBean("wannaflyDatabaseManager");
     }
 }


### PR DESCRIPTION
## 📌 작업 내용

### 테스트 격리 환경 구성
`src/test/java/.../sopport `패키지 하위에 테스트 격리를 위한 설정을 해놓았어요. 이제부터 모든 스프링 컨테이너를 띄우는 테스트 클래스 위에 `@ExtendWith(WannaflyTestIsolationExtension.class)` 어노테이션을 달면 매 테스트가 끝날 때마다 DB 테이블을 truncate하는 쿼리가 나갑니다. 그러면 한 테스트에서 변경한 데이터 때문에 다른 테스트가 영향 받는 일이 사라지게 됩니다.


### Rest Docs 세팅
API 자동 문서화를 위한 rest docs 세팅을 했습니다. build.gradle에 의존성 설정만 해놓은 상태인데요. api 문서화를 위한 테스트 작성법은 다음에 따로 문서화를 해보겠습니다~


## 📝 리뷰 요청
모르는 코드 량이 많지 않으니 모르는 거 있으면 적극적으로 물어봐도 됩니다~~


## 💌 참고 사항
첫 PR이니까 시험 삼아 1개라도 코드 리뷰(질문)을 남겨보는 것도 좋을 듯요!

