### PR TITLE
feat: 로그인 실패 처리와 LoginMember 구현

### DIFF
--- a/src/main/java/com/kusitms/wannafly/auth/AuthConfig.java
+++ b/src/main/java/com/kusitms/wannafly/auth/AuthConfig.java
@@ -1,0 +1,20 @@
+package com.kusitms.wannafly.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthConfig implements WebMvcConfigurer {
+
+    private final LoginMemberResolver loginMemberResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberResolver);
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/auth/LoginMember.java
+++ b/src/main/java/com/kusitms/wannafly/auth/LoginMember.java
@@ -1,0 +1,4 @@
+package com.kusitms.wannafly.auth;
+
+public record LoginMember(Long id) {
+}

--- a/src/main/java/com/kusitms/wannafly/auth/LoginMemberResolver.java
+++ b/src/main/java/com/kusitms/wannafly/auth/LoginMemberResolver.java
@@ -1,0 +1,45 @@
+package com.kusitms.wannafly.auth;
+
+import com.kusitms.wannafly.auth.token.JwtSupport;
+import com.kusitms.wannafly.auth.token.JwtTokenProvider;
+import com.kusitms.wannafly.auth.token.TokenPayload;
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = getAccessToken(request);
+        TokenPayload payload = jwtTokenProvider.getPayload(accessToken);
+        return new LoginMember(payload.id());
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        return JwtSupport.extractToken(Objects.requireNonNull(request))
+                .orElseThrow(() -> BusinessException.from(ErrorCode.AUTHORIZATION_FAIL));
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/auth/security/SecurityConfig.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.kusitms.wannafly.auth.security;
 
+import com.kusitms.wannafly.auth.security.authentication.OAuthLoginFailureHandler;
 import com.kusitms.wannafly.auth.security.authentication.OAuthLoginSuccessHandler;
 import com.kusitms.wannafly.auth.security.authentication.PrincipalOAuth2UserService;
 import com.kusitms.wannafly.auth.security.authoriization.JwtAuthorizationFilter;
@@ -21,6 +22,7 @@ public class SecurityConfig {
 
     private final PrincipalOAuth2UserService userService;
     private final OAuthLoginSuccessHandler successHandler;
+    private final OAuthLoginFailureHandler failureHandler;
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final UnAuthorizationEntryPoint unauthorizationEntryPoint;
 
@@ -44,7 +46,9 @@ public class SecurityConfig {
 
                 .oauth2Login()
                 .userInfoEndpoint().userService(userService).and()
-                .successHandler(successHandler).and()
+                .successHandler(successHandler)
+                .failureHandler(failureHandler)
+                .and()
 
                 .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
 

--- a/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginFailureHandler.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 @Component
 public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
 
-    @Value("${security.redirect-url}")
+    @Value("${security.oauth.failure-redirect-url}")
     private String redirectUrl;
 
     @Override
@@ -24,6 +24,6 @@ public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
         OAuth2AuthenticationException oAuthException = (OAuth2AuthenticationException) exception;
         OAuth2Error oAuth2Error = oAuthException.getError();
 
-        response.sendRedirect(redirectUrl + "/login-fail?code=" + oAuth2Error.getErrorCode());
+        response.sendRedirect(redirectUrl + "?errorCode=" + oAuth2Error.getErrorCode());
     }
 }

--- a/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginFailureHandler.java
@@ -1,0 +1,29 @@
+package com.kusitms.wannafly.auth.security.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Value("${security.redirect-url}")
+    private String redirectUrl;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        OAuth2AuthenticationException oAuthException = (OAuth2AuthenticationException) exception;
+        OAuth2Error oAuth2Error = oAuthException.getError();
+
+        response.sendRedirect(redirectUrl + "/login-fail?code=" + oAuth2Error.getErrorCode());
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginSuccessHandler.java
@@ -19,7 +19,7 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String SET_COOKIE = "Set-Cookie";
 
-    @Value("${security.jwt.token.redirect-url}")
+    @Value("${security.redirect-url}")
     private String redirectUrl;
 
     @Override
@@ -32,6 +32,6 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         response.setContentType("application/json;charset=UTF-8");
         response.addHeader(SET_COOKIE, cookie.toString());
-        response.sendRedirect(redirectUrl + "?accessToken=" + oauth2Member.getAccessToken());
+        response.sendRedirect(redirectUrl + "/token?accessToken=" + oauth2Member.getAccessToken());
     }
 }

--- a/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authentication/OAuthLoginSuccessHandler.java
@@ -19,7 +19,7 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String SET_COOKIE = "Set-Cookie";
 
-    @Value("${security.redirect-url}")
+    @Value("${security.oauth.success-redirect-url}")
     private String redirectUrl;
 
     @Override
@@ -32,6 +32,6 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         response.setContentType("application/json;charset=UTF-8");
         response.addHeader(SET_COOKIE, cookie.toString());
-        response.sendRedirect(redirectUrl + "/token?accessToken=" + oauth2Member.getAccessToken());
+        response.sendRedirect(redirectUrl + "?accessToken=" + oauth2Member.getAccessToken());
     }
 }

--- a/src/main/java/com/kusitms/wannafly/auth/security/authentication/PrincipalOAuth2UserService.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authentication/PrincipalOAuth2UserService.java
@@ -5,11 +5,13 @@ import com.kusitms.wannafly.auth.dto.LoginRequest;
 import com.kusitms.wannafly.auth.dto.LoginResponse;
 import com.kusitms.wannafly.auth.security.oauth.OAuth2Member;
 import com.kusitms.wannafly.auth.security.oauth.OAuthProvider;
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +24,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         LoginRequest loginRequest = toLoginRequest(userRequest);
-        LoginResponse loginResponse = authService.login(loginRequest);
+        LoginResponse loginResponse = login(loginRequest);
         return new OAuth2Member(
                 loginResponse.memberId(),
                 loginResponse.accessToken(),
@@ -34,5 +36,15 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         OAuthProvider oAuthProvider = OAuthProvider.from(userRequest.getClientRegistration().getRegistrationId());
         return oAuthProvider.toLoginRequest(oAuth2User);
+    }
+
+    private LoginResponse login(LoginRequest loginRequest) {
+        try {
+            return authService.login(loginRequest);
+        } catch (BusinessException exception) {
+            ErrorCode code = exception.getErrorCode();
+            OAuth2Error oAuth2Error = new OAuth2Error(String.valueOf(code.getValue()));
+            throw new OAuth2AuthenticationException(oAuth2Error);
+        }
     }
 }

--- a/src/main/java/com/kusitms/wannafly/auth/security/authoriization/UnAuthorizationEntryPoint.java
+++ b/src/main/java/com/kusitms/wannafly/auth/security/authoriization/UnAuthorizationEntryPoint.java
@@ -6,6 +6,7 @@ import com.kusitms.wannafly.exception.ExceptionResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,7 @@ public class UnAuthorizationEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException) throws IOException {
         ErrorCode errorCode = ErrorCode.AUTHORIZATION_FAIL;
         response.setStatus(errorCode.getHttpStatusCode());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
         PrintWriter writer = response.getWriter();
         ExceptionResponse errorResponse = new ExceptionResponse(errorCode.getValue(), errorCode.getMessage());
         writer.println(objectMapper.writeValueAsString(errorResponse));

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,7 +49,9 @@ security:
   jwt:
     token:
       secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ6.eyJzdWIiOiIiLCJuYW1lIjoiSm3obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt23Lno
-  redirect-url: http://localhost:3000
+  oauth:
+    success-redirect-url: http://localhost:3000/token
+    failure-redirect-url: http://localhost:3000/login-fail
 
 cors:
   allowed:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,7 +49,7 @@ security:
   jwt:
     token:
       secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ6.eyJzdWIiOiIiLCJuYW1lIjoiSm3obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt23Lno
-      redirect-url: http://localhost:3000/token
+  redirect-url: http://localhost:3000
 
 cors:
   allowed:

--- a/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
@@ -1,8 +1,11 @@
 package com.kusitms.wannafly.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.wannafly.auth.AuthConfig;
+import com.kusitms.wannafly.auth.LoginMemberResolver;
 import com.kusitms.wannafly.auth.application.AuthService;
 import com.kusitms.wannafly.auth.presentation.AuthController;
+import com.kusitms.wannafly.auth.token.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -14,7 +17,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 @WebMvcTest(controllers = AuthController.class)
-@Import(ControllerTestSecurityConfig.class)
+@Import({
+        ControllerTestSecurityConfig.class,
+        AuthConfig.class,
+        LoginMemberResolver.class,
+        JwtTokenProvider.class
+})
 @AutoConfigureRestDocs
 public class ControllerTest {
 


### PR DESCRIPTION
## 📌 작업 내용
### 이슈 해결
#9
- 중복 이메일 가입으로 인해 소셜 로그인이 실패했을 시에 에러 상황을 프론트에 전달하도록 구현
  - `BusinessException`을 스프링 시큐리티가 인식할 수 있는 `OAuth2AuthenticationException`으로 예외 전환
  - `AuthenticationFailureHandler`를 구현하여 에러 처리

### 로그인한 회원 식별자 바로 받아오기
- 앞으로 기능 개발을 위해 `LoginMember` 생성
  - `Controller` 메서드의 파라미터로 넣으면 로그인한 회원의 식별자를 `LoginMember`에서 얻어올 수 있음
 ``` java
    @GetMapping("/api/test")
    public String test(LoginMember loginMember) {
        Long memberId = loginMember.id()
    }
```
  - 기능 개발 시 리소스를 생성할 때 때 회원 id를 함께 넣어줘야 하는 경우가 많을텐데 (외래키 참조) `Controller`에서 로그인한 회원 id를 바로 받아올 수 있음

## 📝 리뷰 요청
- 이 PR을 마지막으로 찐 기능 개발 들어갈테니 전체적으로 코드 살펴보고 모르는 거 질문하기!

## 💌 참고 사항
- 작업 내용에 다 적은 듯?
