### PR TITLE
feat: 지원서의 지원 항목 추가, 지원서 삭제, 지원서 작성 상태 변경 API 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -53,3 +53,9 @@ include::{snippets}/add-application-item/http-request.adoc[]
 include::{snippets}/add-application-item/request-fields.adoc[]
 === Response
 include::{snippets}/add-application-item/http-response.adoc[]
+
+== 지원서 삭제
+=== Request
+include::{snippets}/delete-application-form/http-request.adoc[]
+=== Response
+include::{snippets}/delete-application-form/http-response.adoc[]

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -59,3 +59,11 @@ include::{snippets}/add-application-item/http-response.adoc[]
 include::{snippets}/delete-application-form/http-request.adoc[]
 === Response
 include::{snippets}/delete-application-form/http-response.adoc[]
+
+== 지원서 작성 상태 변경
+=== Request
+include::{snippets}/application-form-state/http-request.adoc[]
+=== Response
+include::{snippets}/application-form-state/http-response.adoc[]
+=== Response 필드
+include::{snippets}/application-form-state/response-fields.adoc[]

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -46,3 +46,10 @@ include::{snippets}/update-application-form/request-fields.adoc[]
 === Response
 include::{snippets}/update-application-form/http-response.adoc[]
 
+== 지원서 지원 항목 추가
+=== Request
+include::{snippets}/add-application-item/http-request.adoc[]
+=== Request 필드
+include::{snippets}/add-application-item/request-fields.adoc[]
+=== Response
+include::{snippets}/add-application-item/http-response.adoc[]

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -4,10 +4,7 @@ import com.kusitms.wannafly.applicationform.command.domain.*;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationAnswer;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationQuestion;
 import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
-import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
-import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormMapper;
-import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
-import com.kusitms.wannafly.applicationform.command.dto.ApplicationItemCreateRequest;
+import com.kusitms.wannafly.applicationform.command.dto.*;
 import com.kusitms.wannafly.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -54,5 +51,9 @@ public class ApplicationFormService {
         Writer writer = new Writer(loginMember.id());
         ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
         applicationFormRepository.delete(form);
+    }
+
+    public FormStateResponse changeState(Long applicationFormId, LoginMember loginMember) {
+        return null;
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -49,4 +49,10 @@ public class ApplicationFormService {
         applicationFormRepository.flush();
         return item.getId();
     }
+
+    public void deleteForm(Long applicationFormId, LoginMember loginMember) {
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
+        applicationFormRepository.delete(form);
+    }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -1,7 +1,6 @@
 package com.kusitms.wannafly.applicationform.command.application;
 
-import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
-import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
+import com.kusitms.wannafly.applicationform.command.domain.*;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormMapper;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
@@ -21,7 +20,8 @@ public class ApplicationFormService {
     private final ApplicationFormRepository applicationFormRepository;
 
     public Long createForm(LoginMember loginMember, ApplicationFormCreateRequest request) {
-        ApplicationForm applicationForm = ApplicationFormMapper.toDomain(request, loginMember.id());
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm applicationForm = ApplicationFormMapper.toDomain(request, writer);
         applicationFormRepository.save(applicationForm);
         return applicationForm.getId();
     }
@@ -29,19 +29,31 @@ public class ApplicationFormService {
     public void updateForm(Long applicationFormId,
                            LoginMember loginMember,
                            ApplicationFormUpdateRequest request) {
-        ApplicationForm originalForm = getApplicationForm(applicationFormId);
-        ApplicationForm updatedForm = ApplicationFormMapper.toDomain(request, loginMember.id());
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm originalForm = getApplicationForm(applicationFormId, writer);
+        ApplicationForm updatedForm = ApplicationFormMapper.toDomain(request, writer);
         originalForm.update(updatedForm);
-    }
-
-    private ApplicationForm getApplicationForm(Long applicationFormId) {
-        return applicationFormRepository.findById(applicationFormId)
-                .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
     }
 
     public Long addItem(Long applicationFormId,
                         LoginMember loginMember,
                         ApplicationItemCreateRequest request) {
-        return null;
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm form = getApplicationForm(applicationFormId, writer);
+        ApplicationItem item = form.addItem(
+                new ApplicationQuestion(request.applicationQuestion()),
+                new ApplicationAnswer(request.applicationAnswer())
+        );
+        applicationFormRepository.flush();
+        return item.getId();
+    }
+
+    private ApplicationForm getApplicationForm(Long applicationFormId, Writer requester) {
+        ApplicationForm form = applicationFormRepository.findById(applicationFormId)
+                .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
+        if (!form.isWriter(requester)) {
+            throw BusinessException.from(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+        return form;
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -5,6 +5,7 @@ import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormReposi
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormMapper;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
+import com.kusitms.wannafly.applicationform.command.dto.ApplicationItemCreateRequest;
 import com.kusitms.wannafly.auth.LoginMember;
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;
@@ -36,5 +37,11 @@ public class ApplicationFormService {
     private ApplicationForm getApplicationForm(Long applicationFormId) {
         return applicationFormRepository.findById(applicationFormId)
                 .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
+    }
+
+    public Long addItem(Long applicationFormId,
+                        LoginMember loginMember,
+                        ApplicationItemCreateRequest request) {
+        return null;
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -1,10 +1,11 @@
 package com.kusitms.wannafly.applicationform.command.application;
 
-import com.kusitms.wannafly.applicationform.command.domain.*;
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationItem;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationAnswer;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationQuestion;
 import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
-import com.kusitms.wannafly.applicationform.command.domain.value.WritingState;
 import com.kusitms.wannafly.applicationform.command.dto.*;
 import com.kusitms.wannafly.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class ApplicationFormService {
     public FormStateResponse changeState(Long applicationFormId, LoginMember loginMember) {
         Writer writer = new Writer(loginMember.id());
         ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
-        WritingState state = form.changeWritingState();
-        return new FormStateResponse(state.isCompleted);
+        form.changeWritingState();
+        return new FormStateResponse(form.isCompleted());
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -31,7 +31,7 @@ public class ApplicationFormService {
                            LoginMember loginMember,
                            ApplicationFormUpdateRequest request) {
         Writer writer = new Writer(loginMember.id());
-        ApplicationForm originalForm = writerCheckedFormService.findById(applicationFormId, writer);
+        ApplicationForm originalForm = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
         ApplicationForm updatedForm = ApplicationFormMapper.toDomain(request, writer);
         originalForm.update(updatedForm);
     }
@@ -40,7 +40,7 @@ public class ApplicationFormService {
                         LoginMember loginMember,
                         ApplicationItemCreateRequest request) {
         Writer writer = new Writer(loginMember.id());
-        ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
+        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
         ApplicationItem item = form.addItem(
                 new ApplicationQuestion(request.applicationQuestion()),
                 new ApplicationAnswer(request.applicationAnswer())
@@ -51,13 +51,13 @@ public class ApplicationFormService {
 
     public void deleteForm(Long applicationFormId, LoginMember loginMember) {
         Writer writer = new Writer(loginMember.id());
-        ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
+        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
         applicationFormRepository.delete(form);
     }
 
     public FormStateResponse changeState(Long applicationFormId, LoginMember loginMember) {
         Writer writer = new Writer(loginMember.id());
-        ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
+        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
         form.changeWritingState();
         return new FormStateResponse(form.isCompleted());
     }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -4,6 +4,7 @@ import com.kusitms.wannafly.applicationform.command.domain.*;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationAnswer;
 import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationQuestion;
 import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
+import com.kusitms.wannafly.applicationform.command.domain.value.WritingState;
 import com.kusitms.wannafly.applicationform.command.dto.*;
 import com.kusitms.wannafly.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,9 @@ public class ApplicationFormService {
     }
 
     public FormStateResponse changeState(Long applicationFormId, LoginMember loginMember) {
-        return null;
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm form = writerCheckedFormService.findById(applicationFormId, writer);
+        WritingState state = form.changeWritingState();
+        return new FormStateResponse(state.isCompleted);
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormService.java
@@ -1,6 +1,9 @@
 package com.kusitms.wannafly.applicationform.command.application;
 
 import com.kusitms.wannafly.applicationform.command.domain.*;
+import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationAnswer;
+import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationQuestion;
+import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormMapper;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
@@ -2,7 +2,7 @@ package com.kusitms.wannafly.applicationform.command.application;
 
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
-import com.kusitms.wannafly.applicationform.command.domain.Writer;
+import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
@@ -16,7 +16,7 @@ public class WriterCheckedFormService {
 
     private final ApplicationFormRepository applicationFormRepository;
 
-    public ApplicationForm findById(Long applicationFormId, Writer writer) {
+    public ApplicationForm checkWriterAndGet(Long applicationFormId, Writer writer) {
         ApplicationForm form = applicationFormRepository.findById(applicationFormId)
                 .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
         validateWriter(writer, form);

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormService.java
@@ -1,0 +1,31 @@
+package com.kusitms.wannafly.applicationform.command.application;
+
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
+import com.kusitms.wannafly.applicationform.command.domain.Writer;
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WriterCheckedFormService {
+
+    private final ApplicationFormRepository applicationFormRepository;
+
+    public ApplicationForm findById(Long applicationFormId, Writer writer) {
+        ApplicationForm form = applicationFormRepository.findById(applicationFormId)
+                .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
+        validateWriter(writer, form);
+        return form;
+    }
+
+    private static void validateWriter(Writer writer, ApplicationForm form) {
+        if (form.isNotWriter(writer)) {
+            throw BusinessException.from(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -94,8 +94,11 @@ public class ApplicationForm {
         return !this.writer.equals(writer);
     }
 
-    public WritingState changeWritingState() {
+    public void changeWritingState() {
         writingState = writingState.change();
-        return writingState;
+    }
+
+    public Boolean isCompleted() {
+        return writingState.isCompleted;
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -1,5 +1,6 @@
 package com.kusitms.wannafly.applicationform.command.domain;
 
+import com.kusitms.wannafly.applicationform.command.domain.value.*;
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;
 import jakarta.persistence.*;
@@ -24,10 +25,12 @@ public class ApplicationForm {
     private Writer writer;
 
     @Column(nullable = false)
-    private String recruiter;
+    @Embedded
+    private Recruiter recruiter;
 
     @Column(nullable = false, name = "years")
-    private Integer year;
+    @Embedded
+    private ApplicationYear year;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -37,29 +40,18 @@ public class ApplicationForm {
     @OneToMany(mappedBy = "applicationForm", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<ApplicationItem> applicationItems = new ArrayList<>();
 
-    public static ApplicationForm createEmptyForm(Writer writer, String recruiter, Integer year, Semester semester) {
+    public static ApplicationForm createEmptyForm(Writer writer,
+                                                  Recruiter recruiter,
+                                                  ApplicationYear year,
+                                                  Semester semester) {
         return new ApplicationForm(writer, recruiter, year, semester);
     }
 
-    private ApplicationForm(Writer writer, String recruiter, Integer year, Semester semester) {
-        validateRecruiter(recruiter);
-        validateYear(year);
+    private ApplicationForm(Writer writer, Recruiter recruiter, ApplicationYear year, Semester semester) {
         this.writer = writer;
         this.recruiter = recruiter;
         this.year = year;
         this.semester = semester;
-    }
-
-    private void validateRecruiter(String recruiter) {
-        if (recruiter.isBlank()) {
-            throw BusinessException.from(ErrorCode.EMPTY_RECRUITER);
-        }
-    }
-
-    private void validateYear(Integer year) {
-        if (year <= 0) {
-            throw BusinessException.from(ErrorCode.INVALID_YEAR);
-        }
     }
 
     public void update(ApplicationForm updatedForm) {

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -36,6 +36,10 @@ public class ApplicationForm {
     @Column(nullable = false)
     private Semester semester;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private WritingState writingState;
+
 
     @OneToMany(mappedBy = "applicationForm", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<ApplicationItem> applicationItems = new ArrayList<>();
@@ -44,14 +48,19 @@ public class ApplicationForm {
                                                   Recruiter recruiter,
                                                   ApplicationYear year,
                                                   Semester semester) {
-        return new ApplicationForm(writer, recruiter, year, semester);
+        return new ApplicationForm(writer, recruiter, year, semester, WritingState.ON_GOING);
     }
 
-    private ApplicationForm(Writer writer, Recruiter recruiter, ApplicationYear year, Semester semester) {
+    private ApplicationForm(Writer writer,
+                            Recruiter recruiter,
+                            ApplicationYear year,
+                            Semester semester,
+                            WritingState writingState) {
         this.writer = writer;
         this.recruiter = recruiter;
         this.year = year;
         this.semester = semester;
+        this.writingState = writingState;
     }
 
     public void update(ApplicationForm updatedForm) {
@@ -83,5 +92,10 @@ public class ApplicationForm {
 
     public boolean isNotWriter(Writer writer) {
         return !this.writer.equals(writer);
+    }
+
+    public WritingState changeWritingState() {
+        writingState = writingState.change();
+        return writingState;
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -33,6 +35,9 @@ public class ApplicationForm {
     @Column(nullable = false)
     private WritingState writingState;
 
+    @Column(nullable = false)
+    private LocalDateTime lastModifiedTime;
+
     @Embedded
     private ApplicationItems applicationItems = new ApplicationItems();
 
@@ -53,6 +58,14 @@ public class ApplicationForm {
         this.year = year;
         this.semester = semester;
         this.writingState = writingState;
+        updateModifiedDate();
+    }
+
+    public ApplicationItem addItem(ApplicationQuestion question, ApplicationAnswer answer) {
+        ApplicationItem item = new ApplicationItem(this, question, answer);
+        applicationItems.addItem(item);
+        updateModifiedDate();
+        return item;
     }
 
     public void update(ApplicationForm updatedForm) {
@@ -60,16 +73,12 @@ public class ApplicationForm {
         year = updatedForm.getYear();
         semester = updatedForm.getSemester();
         applicationItems.updateItems(updatedForm.getApplicationItems());
-    }
-
-    public ApplicationItem addItem(ApplicationQuestion question, ApplicationAnswer answer) {
-        ApplicationItem item = new ApplicationItem(this, question, answer);
-        applicationItems.addItem(item);
-        return item;
+        updateModifiedDate();
     }
 
     public void addItem(ApplicationItem item) {
         applicationItems.addItem(item);
+        updateModifiedDate();
     }
 
     public boolean isNotWriter(Writer writer) {
@@ -82,5 +91,9 @@ public class ApplicationForm {
 
     public Boolean isCompleted() {
         return writingState.isCompleted;
+    }
+
+    private void updateModifiedDate() {
+        lastModifiedTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -24,11 +24,9 @@ public class ApplicationForm {
     @Embedded
     private Writer writer;
 
-    @Column(nullable = false)
     @Embedded
     private Recruiter recruiter;
 
-    @Column(nullable = false, name = "years")
     @Embedded
     private ApplicationYear year;
 

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -1,15 +1,10 @@
 package com.kusitms.wannafly.applicationform.command.domain;
 
 import com.kusitms.wannafly.applicationform.command.domain.value.*;
-import com.kusitms.wannafly.exception.BusinessException;
-import com.kusitms.wannafly.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,9 +33,8 @@ public class ApplicationForm {
     @Column(nullable = false)
     private WritingState writingState;
 
-
-    @OneToMany(mappedBy = "applicationForm", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    private List<ApplicationItem> applicationItems = new ArrayList<>();
+    @Embedded
+    private ApplicationItems applicationItems = new ApplicationItems();
 
     public static ApplicationForm createEmptyForm(Writer writer,
                                                   Recruiter recruiter,
@@ -62,30 +56,20 @@ public class ApplicationForm {
     }
 
     public void update(ApplicationForm updatedForm) {
-        this.recruiter = updatedForm.getRecruiter();
-        this.year = updatedForm.getYear();
-        this.semester = updatedForm.getSemester();
-
-        List<ApplicationItem> updatedItems = updatedForm.getApplicationItems();
-        updatedItems.forEach(this::updateItem);
-    }
-
-    private void updateItem(ApplicationItem updateItem) {
-        this.applicationItems.stream()
-                .filter(item -> item.getId().equals(updateItem.getId()))
-                .findAny()
-                .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_ITEM))
-                .updateContents(updateItem);
+        recruiter = updatedForm.getRecruiter();
+        year = updatedForm.getYear();
+        semester = updatedForm.getSemester();
+        applicationItems.updateItems(updatedForm.getApplicationItems());
     }
 
     public ApplicationItem addItem(ApplicationQuestion question, ApplicationAnswer answer) {
         ApplicationItem item = new ApplicationItem(this, question, answer);
-        applicationItems.add(item);
+        applicationItems.addItem(item);
         return item;
     }
 
     public void addItem(ApplicationItem item) {
-        applicationItems.add(item);
+        applicationItems.addItem(item);
     }
 
     public boolean isNotWriter(Writer writer) {

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationForm.java
@@ -63,7 +63,6 @@ public class ApplicationForm {
     }
 
     public void update(ApplicationForm updatedForm) {
-        validateWriter(updatedForm.writer);
         this.recruiter = updatedForm.getRecruiter();
         this.year = updatedForm.getYear();
         this.semester = updatedForm.getSemester();
@@ -90,13 +89,7 @@ public class ApplicationForm {
         applicationItems.add(item);
     }
 
-    private void validateWriter(Writer writer) {
-        if (!this.writer.equals(writer)) {
-            throw BusinessException.from(ErrorCode.INVALID_WRITER_OF_FORM);
-        }
-    }
-
-    public boolean isWriter(Writer requester) {
-        return this.writer.equals(requester);
+    public boolean isNotWriter(Writer writer) {
+        return !this.writer.equals(writer);
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItem.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItem.java
@@ -1,5 +1,7 @@
 package com.kusitms.wannafly.applicationform.command.domain;
 
+import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationAnswer;
+import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationQuestion;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItem.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItem.java
@@ -1,10 +1,7 @@
 package com.kusitms.wannafly.applicationform.command.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItems.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationItems.java
@@ -1,0 +1,39 @@
+package com.kusitms.wannafly.applicationform.command.domain;
+
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ApplicationItems {
+
+    @OneToMany(mappedBy = "applicationForm", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private List<ApplicationItem> values = new ArrayList<>();
+
+    public void addItem(ApplicationItem newValue) {
+        values.add(newValue);
+    }
+
+    public void updateItems(ApplicationItems updatedValues) {
+        List<ApplicationItem> updatedItems = updatedValues.getValues();
+        updatedItems.forEach(this::applyUpdating);
+    }
+
+    private void applyUpdating(ApplicationItem updateItem) {
+        values.stream()
+                .filter(item -> item.getId().equals(updateItem.getId()))
+                .findAny()
+                .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_ITEM))
+                .updateContents(updateItem);
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationQuestion.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationQuestion.java
@@ -6,11 +6,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Lob;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Getter
 public class ApplicationQuestion {
 

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/Writer.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/Writer.java
@@ -2,7 +2,6 @@ package com.kusitms.wannafly.applicationform.command.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Lob;
 import lombok.*;
 
 @Embeddable
@@ -10,9 +9,8 @@ import lombok.*;
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter
-public class ApplicationAnswer {
+public class Writer {
 
-    @Column(name = "application_answer", nullable = false)
-    @Lob
-    private String content;
+    @Column(nullable = false, name = "member_id")
+    private Long id;
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationAnswer.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationAnswer.java
@@ -1,4 +1,4 @@
-package com.kusitms.wannafly.applicationform.command.domain;
+package com.kusitms.wannafly.applicationform.command.domain.value;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationQuestion.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationQuestion.java
@@ -1,4 +1,4 @@
-package com.kusitms.wannafly.applicationform.command.domain;
+package com.kusitms.wannafly.applicationform.command.domain.value;
 
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationYear.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationYear.java
@@ -1,0 +1,28 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class ApplicationYear {
+
+    @Column(nullable = false, name = "years")
+    private Integer value;
+
+    public ApplicationYear(Integer value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(Integer value) {
+        if (value <= 0) {
+            throw BusinessException.from(ErrorCode.INVALID_YEAR);
+        }
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Recruiter.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Recruiter.java
@@ -1,0 +1,28 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class Recruiter {
+
+    @Column(nullable = false, name = "recruiter")
+    private String value;
+
+    public Recruiter(String value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(String value) {
+        if (value.isBlank()) {
+            throw BusinessException.from(ErrorCode.EMPTY_RECRUITER);
+        }
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Semester.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Semester.java
@@ -1,4 +1,4 @@
-package com.kusitms.wannafly.applicationform.command.domain;
+package com.kusitms.wannafly.applicationform.command.domain.value;
 
 public enum Semester {
 

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Writer.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/Writer.java
@@ -1,4 +1,4 @@
-package com.kusitms.wannafly.applicationform.command.domain;
+package com.kusitms.wannafly.applicationform.command.domain.value;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/WritingState.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/domain/value/WritingState.java
@@ -1,0 +1,27 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+public enum WritingState {
+
+    COMPLETE(true) {
+        @Override
+        public WritingState change() {
+            return ON_GOING;
+        }
+    },
+    ON_GOING(false) {
+        @Override
+        public WritingState change() {
+            return COMPLETE;
+        }
+    }
+
+    ;
+
+    public final boolean isCompleted;
+
+    WritingState(boolean isCompleted) {
+        this.isCompleted = isCompleted;
+    }
+
+    public abstract WritingState change();
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/dto/ApplicationFormMapper.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/dto/ApplicationFormMapper.java
@@ -1,6 +1,7 @@
 package com.kusitms.wannafly.applicationform.command.dto;
 
 import com.kusitms.wannafly.applicationform.command.domain.*;
+import com.kusitms.wannafly.applicationform.command.domain.value.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -33,7 +34,7 @@ public class ApplicationFormMapper {
 
     private static ApplicationForm createEmptyForm(Writer writer, String recruiter, Integer year, String semester) {
         return ApplicationForm.createEmptyForm(
-                writer, recruiter, year, Semester.from(semester)
+                writer, new Recruiter(recruiter), new ApplicationYear(year), Semester.from(semester)
         );
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/dto/ApplicationFormMapper.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/dto/ApplicationFormMapper.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplicationFormMapper {
 
-    public static ApplicationForm toDomain(ApplicationFormCreateRequest request, Long memberId) {
-        ApplicationForm form = createEmptyForm(memberId, request.recruiter(), request.year(), request.semester());
+    public static ApplicationForm toDomain(ApplicationFormCreateRequest request, Writer writer) {
+        ApplicationForm form = createEmptyForm(writer, request.recruiter(), request.year(), request.semester());
         for (ApplicationItemCreateRequest item : request.applicationItems()) {
             form.addItem(
                     new ApplicationQuestion(item.applicationQuestion()),
@@ -18,8 +18,8 @@ public class ApplicationFormMapper {
         return form;
     }
 
-    public static ApplicationForm toDomain(ApplicationFormUpdateRequest request, Long memberId) {
-        ApplicationForm form = createEmptyForm(memberId, request.recruiter(), request.year(), request.semester());
+    public static ApplicationForm toDomain(ApplicationFormUpdateRequest request, Writer writer) {
+        ApplicationForm form = createEmptyForm(writer, request.recruiter(), request.year(), request.semester());
         for (ApplicationItemUpdateRequest requestItem : request.applicationItems()) {
             form.addItem(
                     new ApplicationItem(
@@ -31,9 +31,9 @@ public class ApplicationFormMapper {
         return form;
     }
 
-    private static ApplicationForm createEmptyForm(Long memberId, String recruiter, Integer year, String semester) {
+    private static ApplicationForm createEmptyForm(Writer writer, String recruiter, Integer year, String semester) {
         return ApplicationForm.createEmptyForm(
-                memberId, recruiter, year, Semester.from(semester)
+                writer, recruiter, year, Semester.from(semester)
         );
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/dto/FormStateResponse.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/dto/FormStateResponse.java
@@ -1,0 +1,4 @@
+package com.kusitms.wannafly.applicationform.command.dto;
+
+public record FormStateResponse(Boolean isCompleted) {
+}

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
@@ -3,6 +3,7 @@ package com.kusitms.wannafly.applicationform.command.presentation;
 import com.kusitms.wannafly.applicationform.command.application.ApplicationFormService;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
+import com.kusitms.wannafly.applicationform.command.dto.ApplicationItemCreateRequest;
 import com.kusitms.wannafly.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +32,14 @@ public class ApplicationFormController {
                                            LoginMember loginMember) {
         applicationFormService.updateForm(applicationFormId, loginMember, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("{applicationFormId}/items")
+    public ResponseEntity<Void> addItem(@PathVariable Long applicationFormId,
+                                        @RequestBody ApplicationItemCreateRequest request,
+                                        LoginMember loginMember) {
+        Long itemId = applicationFormService.addItem(applicationFormId, loginMember, request);
+        return ResponseEntity.created(URI.create("/application-items/" + itemId))
+                .build();
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
@@ -4,6 +4,7 @@ import com.kusitms.wannafly.applicationform.command.application.ApplicationFormS
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationItemCreateRequest;
+import com.kusitms.wannafly.applicationform.command.dto.FormStateResponse;
 import com.kusitms.wannafly.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -48,5 +49,12 @@ public class ApplicationFormController {
                                            LoginMember loginMember) {
         applicationFormService.deleteForm(applicationFormId, loginMember);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("{applicationFormId}/state")
+    public ResponseEntity<FormStateResponse> changeFormState(@PathVariable Long applicationFormId,
+                                                LoginMember loginMember) {
+        FormStateResponse response = applicationFormService.changeState(applicationFormId, loginMember);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormController.java
@@ -42,4 +42,11 @@ public class ApplicationFormController {
         return ResponseEntity.created(URI.create("/application-items/" + itemId))
                 .build();
     }
+
+    @DeleteMapping("{applicationFormId}")
+    public ResponseEntity<Void> deleteForm(@PathVariable Long applicationFormId,
+                                           LoginMember loginMember) {
+        applicationFormService.deleteForm(applicationFormId, loginMember);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
@@ -1,6 +1,7 @@
 package com.kusitms.wannafly.applicationform.query;
 
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
+import com.kusitms.wannafly.applicationform.command.domain.Writer;
 import com.kusitms.wannafly.applicationform.query.dto.ApplicationFormResponse;
 import com.kusitms.wannafly.auth.LoginMember;
 import com.kusitms.wannafly.exception.BusinessException;
@@ -17,8 +18,9 @@ public class ApplicationFormQueryService {
     private final ApplicationFormQueryRepository applicationFormQueryRepository;
 
     public ApplicationFormResponse findOne(Long applicationFormId, LoginMember loginMember) {
+        Writer requester = new Writer(loginMember.id());
         ApplicationForm applicationForm = getApplicationForm(applicationFormId);
-        validateWriter(loginMember, applicationForm);
+        validateWriter(requester, applicationForm);
         return ApplicationFormResponse.from(applicationForm);
     }
 
@@ -27,8 +29,8 @@ public class ApplicationFormQueryService {
                 .orElseThrow(() -> BusinessException.from(ErrorCode.NOT_FOUND_APPLICATION_FORM));
     }
 
-    private void validateWriter(LoginMember loginMember, ApplicationForm applicationForm) {
-        if (!loginMember.equalsId(applicationForm.getMemberId())) {
+    private void validateWriter(Writer requester, ApplicationForm applicationForm) {
+        if (!applicationForm.isWriter(requester)) {
             throw BusinessException.from(ErrorCode.INVALID_WRITER_OF_FORM);
         }
     }

--- a/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
@@ -1,7 +1,7 @@
 package com.kusitms.wannafly.applicationform.query;
 
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
-import com.kusitms.wannafly.applicationform.command.domain.Writer;
+import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
 import com.kusitms.wannafly.applicationform.query.dto.ApplicationFormResponse;
 import com.kusitms.wannafly.auth.LoginMember;
 import com.kusitms.wannafly.exception.BusinessException;

--- a/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/query/ApplicationFormQueryService.java
@@ -30,7 +30,7 @@ public class ApplicationFormQueryService {
     }
 
     private void validateWriter(Writer requester, ApplicationForm applicationForm) {
-        if (!applicationForm.isWriter(requester)) {
+        if (applicationForm.isNotWriter(requester)) {
             throw BusinessException.from(ErrorCode.INVALID_WRITER_OF_FORM);
         }
     }

--- a/src/main/java/com/kusitms/wannafly/applicationform/query/dto/ApplicationFormResponse.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/query/dto/ApplicationFormResponse.java
@@ -12,8 +12,8 @@ public record ApplicationFormResponse(
 ) {
     public static ApplicationFormResponse from(ApplicationForm applicationForm) {
         return new ApplicationFormResponse(
-                applicationForm.getRecruiter(),
-                applicationForm.getYear(),
+                applicationForm.getRecruiter().getValue(),
+                applicationForm.getYear().getValue(),
                 applicationForm.getSemester().name().toLowerCase(),
                 applicationForm.getApplicationItems()
                         .stream()

--- a/src/main/java/com/kusitms/wannafly/applicationform/query/dto/ApplicationFormResponse.java
+++ b/src/main/java/com/kusitms/wannafly/applicationform/query/dto/ApplicationFormResponse.java
@@ -15,7 +15,7 @@ public record ApplicationFormResponse(
                 applicationForm.getRecruiter().getValue(),
                 applicationForm.getYear().getValue(),
                 applicationForm.getSemester().name().toLowerCase(),
-                applicationForm.getApplicationItems()
+                applicationForm.getApplicationItems().getValues()
                         .stream()
                         .map(ApplicationItemResponse::from)
                         .toList()

--- a/src/main/resources/db/migration/V2__application_form_add.sql
+++ b/src/main/resources/db/migration/V2__application_form_add.sql
@@ -4,6 +4,7 @@ CREATE TABLE application_form
     member_id           BIGINT                NOT NULL,
     writing_state       VARCHAR(255)          NOT NULL,
     recruiter           VARCHAR(255)          NOT NULL,
+    last_modified_time  datetime              NOT NULL,
     years               INT                   NOT NULL,
     semester            VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_applicationform PRIMARY KEY (application_form_id)

--- a/src/main/resources/db/migration/V2__application_form_add.sql
+++ b/src/main/resources/db/migration/V2__application_form_add.sql
@@ -2,6 +2,7 @@ CREATE TABLE application_form
 (
     application_form_id BIGINT AUTO_INCREMENT NOT NULL,
     member_id           BIGINT                NOT NULL,
+    writing_state       VARCHAR(255)          NOT NULL,
     recruiter           VARCHAR(255)          NOT NULL,
     years               INT                   NOT NULL,
     semester            VARCHAR(255)          NOT NULL,

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -458,6 +458,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_지원서_등록">지원서 등록</a></li>
 <li><a href="#_나의_지원서_하나_조회">나의 지원서 하나 조회</a></li>
 <li><a href="#_지원서_수정">지원서 수정</a></li>
+<li><a href="#_지원서_지원_항목_추가">지원서 지원 항목 추가</a></li>
+<li><a href="#_지원서_삭제">지원서 삭제</a></li>
+<li><a href="#_지원서_작성_상태_변경">지원서 작성 상태 변경</a></li>
 </ul>
 </li>
 </ul>
@@ -578,7 +581,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/application-forms HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzNzI5MzMwLCJleHAiOjE2ODM3MzExMzB9.cEDNXCoOZXYqKPWhQ8Fg1Ew5E376JcNgNzxZakhKTjU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDAzLCJleHAiOjE2ODM5MDg4MDN9.snJOlzgZUl_E1FFm9WVr2FbRNLc28bdiWoX-uv6TnOA
 Content-Length: 6623
 Host: www.api.wannafly.co.kr
 
@@ -673,7 +676,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/application-forms/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzNzI5MzMwLCJleHAiOjE2ODM3MzExMzB9.cEDNXCoOZXYqKPWhQ8Fg1Ew5E376JcNgNzxZakhKTjU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDA0LCJleHAiOjE2ODM5MDg4MDR9.mLIEuWC4Kn13iGHkZv1y2Su_tLVkwtc3AIEEbk7PUNM
 Host: www.api.wannafly.co.kr</code></pre>
 </div>
 </div>
@@ -776,7 +779,7 @@ Content-Length: 6710
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/application-forms/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzNzI5MzMwLCJleHAiOjE2ODM3MzExMzB9.cEDNXCoOZXYqKPWhQ8Fg1Ew5E376JcNgNzxZakhKTjU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDA0LCJleHAiOjE2ODM5MDg4MDR9.mLIEuWC4Kn13iGHkZv1y2Su_tLVkwtc3AIEEbk7PUNM
 Content-Length: 7687
 Host: www.api.wannafly.co.kr
 
@@ -869,11 +872,176 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_지원서_지원_항목_추가"><a class="link" href="#_지원서_지원_항목_추가">지원서 지원 항목 추가</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_request_6"><a class="link" href="#_request_6">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/application-forms/1/items HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDA0LCJleHAiOjE2ODM5MDg4MDR9.mLIEuWC4Kn13iGHkZv1y2Su_tLVkwtc3AIEEbk7PUNM
+Content-Length: 2165
+Host: www.api.wannafly.co.kr
+
+{
+  "applicationQuestion" : "본 직군으로 지원을 결정하시게 된 계기를 말하고, 그 동안의 노력도 말해주세요. (1000자 이내)",
+  "applicationAnswer" : "저는 Back-end 분야를 희망합니다. 백엔드 개발을 진행하고 학습할 수록 여러가지 매력을 느꼈습니다.\n첫 번째로 서비스의 비즈니스 규칙을 구현할 수 있다는 점입니다. 서비스에는 여러 규칙과 제약이 존재하고 이들은 반드시 지켜지고 절차대로 이행되어야 합니다. 버그를 줄이고 효율적으로 규칙과 제약을 구현하기 위해 고민하고 동료들과 소통하는 과정이 가치있게 느껴졌고 재미 또한 느꼈습니다.\n두 번째로 규칙과 제약을 구현한 코드를 보호하고 유지보수하기 쉽게 하기 위해 여러 디자인 패턴이나 개발 방법론을 고민하고 적용하는 과정도 흥미로웠습니다. 코드의 길이부터 의존성 방향, 나아가 전체적인 소프트웨어 아키텍처 설계까지 정답이 없는 문제에 자신과 팀만의 답을 찾아나가는 과정을 계속 겪어보고 싶다는 생각을 하고 있습니다.\n백엔드 개발자를 희망한 이후부터 필요한 역량을 쌓기 위해 꾸준히 학습해왔습니다. 처음에는 인터넷 강의로 학습을 시작했습니다. 혼자보다 함께 학습하고 싶어서 스터디에 참여해 보기도 했지만 독학에 한계를 느꼈습니다. 양질의 학습과 경험을 하고 싶어서 ‘우아한테크코스’라는 교육 프로그램에 지원했고 한 달 간 코딩 테스트와 과제 전형을 거쳐 합격할 수 있었습니다. 교육 중에는 매주 과제를 수행하고 코드 리뷰를 받으며 TDD, 객체지향, 자바 및 스프링 등의 학습을 진행했습니다. 학습이 어느정도 진행된 후에는 5개월 간 팀 프로젝트를 진행했으며 지속적인 배포와 유지보수를 경험할 수 있었습니다.\n교육을 수료한 이후에는 졸업 프로젝트와 IT 연합 동아리에서 백엔드 개발자로 참여하여 협업을 계속 이어나가고 있습니다.\n"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_request_필드_3"><a class="link" href="#_request_필드_3">Request 필드</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>applicationQuestion</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지원 문항</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>applicationAnswer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지원 답변</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_response_6"><a class="link" href="#_response_6">Response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: /application-items/4
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_지원서_삭제"><a class="link" href="#_지원서_삭제">지원서 삭제</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_request_7"><a class="link" href="#_request_7">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/application-forms/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDA0LCJleHAiOjE2ODM5MDg4MDR9.mLIEuWC4Kn13iGHkZv1y2Su_tLVkwtc3AIEEbk7PUNM
+Host: www.api.wannafly.co.kr</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_7"><a class="link" href="#_response_7">Response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_지원서_작성_상태_변경"><a class="link" href="#_지원서_작성_상태_변경">지원서 작성 상태 변경</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_request_8"><a class="link" href="#_request_8">Request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/application-forms/1/state HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjgzOTA3MDA0LCJleHAiOjE2ODM5MDg4MDR9.mLIEuWC4Kn13iGHkZv1y2Su_tLVkwtc3AIEEbk7PUNM
+Host: www.api.wannafly.co.kr</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_8"><a class="link" href="#_response_8">Response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 26
+
+{
+  "isCompleted" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_response_필드_3"><a class="link" href="#_response_필드_3">Response 필드</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isCompleted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지원서 작성 완료 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-10 22:08:09 +0900
+Last updated 2023-05-13 00:20:02 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static com.kusitms.wannafly.Acceptance.fixture.AcceptanceFixture.*;
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_CREATE_REQUEST;
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_UPDATE_REQUEST;
+import static com.kusitms.wannafly.Acceptance.fixture.ApplicationFormAcceptanceFixture.*;
+import static com.kusitms.wannafly.Acceptance.fixture.AuthAcceptanceFixture.소셜_로그인을_한다;
+import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -35,9 +35,10 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
 
 
         // then
+        long applicationFormId = extractCreatedId(response);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(response.header(HttpHeaders.LOCATION)).isEqualTo("/application-forms/" + 1)
+                () -> assertThat(applicationFormId).isEqualTo(1)
         );
     }
 
@@ -87,11 +88,27 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private Long 지원서를_등록하고_ID를_응답(String accessToken) {
-        return Long.parseLong(
-                지원서를_등록한다(accessToken, FORM_CREATE_REQUEST)
-                        .header(HttpHeaders.LOCATION)
-                        .split("/")[2]
+    @Test
+    void 지원서의_지원_항목을_추가한다() {
+        // given
+        Long formId = 지원서를_등록하고_ID를_응답(accessToken);
+
+        // when
+        ExtractableResponse<Response> response = 지원_항목을_추가한다(accessToken, formId, ITEM_CREATE_REQUEST);
+
+        // then
+        long applicationItemId = extractCreatedId(response);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(applicationItemId).isEqualTo(4)
         );
+    }
+
+    private Long 지원서를_등록하고_ID를_응답(String accessToken) {
+        return extractCreatedId(지원서를_등록한다(accessToken, FORM_CREATE_REQUEST));
+    }
+
+    private long extractCreatedId(ExtractableResponse<Response> response) {
+        return Long.parseLong(response.header(HttpHeaders.LOCATION).split("/")[2]);
     }
 }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
@@ -116,6 +116,39 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
+    @Test
+    void 나의_지원서를_작성_완료한다() {
+        // given
+        Long formId = 지원서를_등록하고_ID를_응답(accessToken);
+
+        // when
+        ExtractableResponse<Response> response = 지원서_상태_변경(accessToken, formId);
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isCompleted")).isEqualTo(true)
+        );
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void 완료_지원서를_작성중으로_한다() {
+        // given
+        Long formId = 지원서를_등록하고_ID를_응답(accessToken);
+        지원서_상태_변경(accessToken, formId);
+
+        // when
+        ExtractableResponse<Response> response = 지원서_상태_변경(accessToken, formId);
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.jsonPath().getBoolean("isCompleted")).isEqualTo(false)
+        );
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
     private Long 지원서를_등록하고_ID를_응답(String accessToken) {
         return extractCreatedId(지원서를_등록한다(accessToken, FORM_CREATE_REQUEST));
     }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
@@ -129,7 +129,7 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getBoolean("isCompleted")).isEqualTo(true)
         );
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     @Test
@@ -146,7 +146,7 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.jsonPath().getBoolean("isCompleted")).isEqualTo(false)
         );
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     private Long 지원서를_등록하고_ID를_응답(String accessToken) {

--- a/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/ApplicationFormAcceptanceTest.java
@@ -104,6 +104,18 @@ class ApplicationFormAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @Test
+    void 나의_지원서를_삭제한다() {
+        // given
+        Long formId = 지원서를_등록하고_ID를_응답(accessToken);
+
+        // when
+        ExtractableResponse<Response> response = 지원서를_삭제한다(accessToken, formId);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
     private Long 지원서를_등록하고_ID를_응답(String accessToken) {
         return extractCreatedId(지원서를_등록한다(accessToken, FORM_CREATE_REQUEST));
     }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/AuthAcceptanceTest.java
@@ -8,7 +8,7 @@ import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static com.kusitms.wannafly.Acceptance.fixture.AcceptanceFixture.*;
+import static com.kusitms.wannafly.Acceptance.fixture.AuthAcceptanceFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
@@ -57,4 +57,14 @@ public class ApplicationFormAcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지원서를_삭제한다(String accessToken, Long formId) {
+        return RestAssured.given().log().all()
+                .when()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .delete("/api/application-forms/" + formId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
@@ -67,4 +67,14 @@ public class ApplicationFormAcceptanceFixture {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지원서_상태_변경(String accessToken, Long formId) {
+        return RestAssured.given().log().all()
+                .when()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .patch("/api/application-forms/" + formId + "/state")
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/fixture/ApplicationFormAcceptanceFixture.java
@@ -2,39 +2,14 @@ package com.kusitms.wannafly.Acceptance.fixture;
 
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.applicationform.command.dto.ApplicationFormUpdateRequest;
+import com.kusitms.wannafly.applicationform.command.dto.ApplicationItemCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
-public class AcceptanceFixture {
-
-    public static ExtractableResponse<Response> 소셜_로그인을_한다(String registrationId) {
-        return RestAssured.given().log().all()
-                .when()
-                .get("/mock/oauth2/authorization/" + registrationId)
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> 토큰을_재발급_한다(String refreshToken) {
-        return RestAssured.given().log().all()
-                .when()
-                .cookie("refreshToken", refreshToken)
-                .post("/accessToken")
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> 로그아웃_한다(String refreshToken) {
-        return RestAssured.given().log().all()
-                .when()
-                .cookie("refreshToken", refreshToken)
-                .delete("/refreshToken")
-                .then().log().all()
-                .extract();
-    }
+public class ApplicationFormAcceptanceFixture {
 
     public static ExtractableResponse<Response> 지원서를_등록한다(String accessToken, ApplicationFormCreateRequest request) {
         return RestAssured.given().log().all()
@@ -66,6 +41,19 @@ public class AcceptanceFixture {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .patch("/api/application-forms/" + formId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지원_항목을_추가한다(String accessToken,
+                                                            Long formId,
+                                                            ApplicationItemCreateRequest request) {
+        return RestAssured.given().log().all()
+                .when()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/api/application-forms/" + formId + "/items")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/kusitms/wannafly/Acceptance/fixture/AuthAcceptanceFixture.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/fixture/AuthAcceptanceFixture.java
@@ -1,0 +1,34 @@
+package com.kusitms.wannafly.Acceptance.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class AuthAcceptanceFixture {
+
+    public static ExtractableResponse<Response> 소셜_로그인을_한다(String registrationId) {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/mock/oauth2/authorization/" + registrationId)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 토큰을_재발급_한다(String refreshToken) {
+        return RestAssured.given().log().all()
+                .when()
+                .cookie("refreshToken", refreshToken)
+                .post("/accessToken")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 로그아웃_한다(String refreshToken) {
+        return RestAssured.given().log().all()
+                .when()
+                .cookie("refreshToken", refreshToken)
+                .delete("/refreshToken")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
@@ -17,8 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_CREATE_REQUEST;
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_UPDATE_REQUEST;
+import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -95,6 +94,44 @@ class ApplicationFormServiceTest extends ServiceTest {
             LoginMember loginMember = new LoginMember(2L);
             assertThatThrownBy(() -> applicationFormService.updateForm(
                     formId, loginMember, FORM_UPDATE_REQUEST)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+    }
+
+    @DisplayName("지원서의 지원 항목을 추가할 때")
+    @Nested
+    class AddItemTest {
+
+        @Test
+        void 로그인_회원이_지원서_작성자면_추가_가능하다() {
+            // given
+            LoginMember loginMember = new LoginMember(1L);
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+
+            // when
+            Long itemId = applicationFormService.addItem(formId, loginMember, ITEM_CREATE_REQUEST);
+
+            // then
+            ApplicationFormResponse form = applicationFormQueryService.findOne(formId, loginMember);
+            assertAll(
+                    () -> assertThat(itemId).isEqualTo(4),
+                    () -> assertThat(form.applicationItems()).hasSize(4)
+            );
+        }
+
+        @Test
+        void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
+            // given
+            LoginMember formWriter = new LoginMember(1L);
+            Long formId = applicationFormService.createForm(formWriter, FORM_CREATE_REQUEST);
+
+            // when then
+            LoginMember loginMember = new LoginMember(2L);
+            assertThatThrownBy(() -> applicationFormService.addItem(
+                    formId, loginMember, ITEM_CREATE_REQUEST)
             )
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
@@ -2,6 +2,7 @@ package com.kusitms.wannafly.applicationform.command.application;
 
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
 import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
+import com.kusitms.wannafly.applicationform.command.dto.FormStateResponse;
 import com.kusitms.wannafly.applicationform.query.ApplicationFormQueryService;
 import com.kusitms.wannafly.applicationform.query.dto.ApplicationFormResponse;
 import com.kusitms.wannafly.applicationform.query.dto.ApplicationItemResponse;
@@ -162,6 +163,36 @@ class ApplicationFormServiceTest extends ServiceTest {
             // when then
             LoginMember requester = new LoginMember(2L);
             assertThatThrownBy(() -> applicationFormService.deleteForm(formId, requester))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+    }
+
+    @DisplayName("지원서의 작성 상태를 변경할 때")
+    @Nested
+    class ChangeTest {
+
+        @Test
+        void 로그인_회원이_지원서_작성자면_변경_가능하다() {
+            // given
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+
+            // when
+            FormStateResponse actual = applicationFormService.changeState(formId, loginMember);
+
+            // then
+            assertThat(actual.isCompleted()).isEqualTo(true);
+        }
+
+        @Test
+        void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
+            // given
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+
+            // when then
+            LoginMember requester = new LoginMember(2L);
+            assertThatThrownBy(() -> applicationFormService.changeState(formId, requester))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/ApplicationFormServiceTest.java
@@ -186,6 +186,19 @@ class ApplicationFormServiceTest extends ServiceTest {
         }
 
         @Test
+        void 완료_상태_지원서는_작성_중이_된다() {
+            // given
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+            applicationFormService.changeState(formId, loginMember);
+
+            // when
+            FormStateResponse actual = applicationFormService.changeState(formId, loginMember);
+
+            // then
+            assertThat(actual.isCompleted()).isEqualTo(false);
+        }
+
+        @Test
         void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
             // given
             Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
@@ -42,7 +42,7 @@ class WriterCheckedFormServiceTest extends ServiceTest {
             ApplicationForm saved = applicationFormRepository.save(form);
 
             // when
-            ApplicationForm actual = writerCheckedFormService.findById(saved.getId(), writer);
+            ApplicationForm actual = writerCheckedFormService.checkWriterAndGet(saved.getId(), writer);
 
             // then
             Assertions.assertThat(actual.getId()).isEqualTo(saved.getId());
@@ -58,7 +58,7 @@ class WriterCheckedFormServiceTest extends ServiceTest {
 
             // when
             Writer requester = new Writer(2L);
-            assertThatThrownBy(() -> writerCheckedFormService.findById(saved.getId(), requester))
+            assertThatThrownBy(() -> writerCheckedFormService.checkWriterAndGet(saved.getId(), requester))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
@@ -1,9 +1,10 @@
 package com.kusitms.wannafly.applicationform.command.application;
 
-import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
-import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
-import com.kusitms.wannafly.applicationform.command.domain.Semester;
-import com.kusitms.wannafly.applicationform.command.domain.Writer;
+import com.kusitms.wannafly.applicationform.command.domain.*;
+import com.kusitms.wannafly.applicationform.command.domain.value.Recruiter;
+import com.kusitms.wannafly.applicationform.command.domain.value.Semester;
+import com.kusitms.wannafly.applicationform.command.domain.value.Writer;
+import com.kusitms.wannafly.applicationform.command.domain.value.ApplicationYear;
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;
 import com.kusitms.wannafly.support.ServiceTest;
@@ -29,12 +30,14 @@ class WriterCheckedFormServiceTest extends ServiceTest {
 
         private final Long writerId = 1L;
         private final Writer writer = new Writer(writerId);
+        private final Recruiter recruiter = new Recruiter("큐시즘");
+        private final ApplicationYear year = new ApplicationYear(2023);
 
         @Test
         void 지원서_작성자는_조회_가능하다() {
             // given
             ApplicationForm form = ApplicationForm.createEmptyForm(
-                    writer, "큐시즘", 2023, Semester.FIRST_HALF
+                    writer, recruiter, year, Semester.FIRST_HALF
             );
             ApplicationForm saved = applicationFormRepository.save(form);
 
@@ -49,7 +52,7 @@ class WriterCheckedFormServiceTest extends ServiceTest {
         void 지원서_작성자가_아니면_예외가_발생한다() {
             // given
             ApplicationForm form = ApplicationForm.createEmptyForm(
-                    writer, "큐시즘", 2023, Semester.FIRST_HALF
+                    writer, recruiter, year, Semester.FIRST_HALF
             );
             ApplicationForm saved = applicationFormRepository.save(form);
 

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
@@ -24,7 +24,7 @@ class WriterCheckedFormServiceTest extends ServiceTest {
     @Autowired
     private ApplicationFormRepository applicationFormRepository;
 
-    @DisplayName("지원서를 조회할 떼")
+    @DisplayName("지원서를 조회할 때")
     @Nested
     class FindTest {
 

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/application/WriterCheckedFormServiceTest.java
@@ -1,0 +1,64 @@
+package com.kusitms.wannafly.applicationform.command.application;
+
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationForm;
+import com.kusitms.wannafly.applicationform.command.domain.ApplicationFormRepository;
+import com.kusitms.wannafly.applicationform.command.domain.Semester;
+import com.kusitms.wannafly.applicationform.command.domain.Writer;
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import com.kusitms.wannafly.support.ServiceTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WriterCheckedFormServiceTest extends ServiceTest {
+
+    @Autowired
+    private WriterCheckedFormService writerCheckedFormService;
+
+    @Autowired
+    private ApplicationFormRepository applicationFormRepository;
+
+    @DisplayName("지원서를 조회할 떼")
+    @Nested
+    class FindTest {
+
+        private final Long writerId = 1L;
+        private final Writer writer = new Writer(writerId);
+
+        @Test
+        void 지원서_작성자는_조회_가능하다() {
+            // given
+            ApplicationForm form = ApplicationForm.createEmptyForm(
+                    writer, "큐시즘", 2023, Semester.FIRST_HALF
+            );
+            ApplicationForm saved = applicationFormRepository.save(form);
+
+            // when
+            ApplicationForm actual = writerCheckedFormService.findById(saved.getId(), writer);
+
+            // then
+            Assertions.assertThat(actual.getId()).isEqualTo(saved.getId());
+        }
+
+        @Test
+        void 지원서_작성자가_아니면_예외가_발생한다() {
+            // given
+            ApplicationForm form = ApplicationForm.createEmptyForm(
+                    writer, "큐시즘", 2023, Semester.FIRST_HALF
+            );
+            ApplicationForm saved = applicationFormRepository.save(form);
+
+            // when
+            Writer requester = new Writer(2L);
+            assertThatThrownBy(() -> writerCheckedFormService.findById(saved.getId(), requester))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -1,5 +1,6 @@
 package com.kusitms.wannafly.applicationform.command.domain;
 
+import com.kusitms.wannafly.applicationform.command.domain.value.*;
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;
 import org.assertj.core.api.ListAssert;
@@ -27,10 +28,12 @@ class ApplicationFormTest {
         void 모집자는_공백일_수_없다(String recruiter) {
             // given
             Writer writer = new Writer(1L);
-            Integer year = 2023;
+            ApplicationYear year = new ApplicationYear(2023);
 
             // when then
-            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(writer, recruiter, year, Semester.FIRST_HALF))
+            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(
+                    writer, new Recruiter(recruiter), year, Semester.FIRST_HALF)
+            )
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.EMPTY_RECRUITER);
@@ -41,10 +44,12 @@ class ApplicationFormTest {
         void 지원년도는_자연수여야_한다(int year) {
             // given
             Writer writer = new Writer(1L);
-            String recruiter = "큐시즘";
+            Recruiter recruiter = new Recruiter("큐시즘");
 
             // when then
-            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(writer, recruiter, year, Semester.FIRST_HALF))
+            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(
+                    writer, recruiter, new ApplicationYear(year), Semester.FIRST_HALF)
+            )
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_YEAR);
@@ -60,7 +65,7 @@ class ApplicationFormTest {
         private final Long itemId2 = 2L;
 
         private final ApplicationForm form = ApplicationForm.createEmptyForm(
-                writer, "큐시즘", 2023, Semester.FIRST_HALF
+                writer, new Recruiter("큐시즘"), new ApplicationYear(2023), Semester.FIRST_HALF
         );
 
         private final ApplicationItem item1 = new ApplicationItem(
@@ -74,13 +79,12 @@ class ApplicationFormTest {
                 new ApplicationAnswer(ANSWER2)
         );
 
+        private final ApplicationForm updated = ApplicationForm.createEmptyForm(
+                writer, new Recruiter("큐시즘 28기"), new ApplicationYear(2024), Semester.SECOND_HALF
+        );
+
         @Test
         void 로그인_회원이_지원서_작성자면_수정_가능하다() {
-            // given
-            ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
-            );
-
             // when
             form.update(updated);
 
@@ -95,10 +99,6 @@ class ApplicationFormTest {
 
         @Test
         void 없는_지원_항목은_수정할_수_없다() {
-            // given
-            ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
-            );
             form.addItem(item1);
             updated.addItem(item2);
 
@@ -114,10 +114,6 @@ class ApplicationFormTest {
             // given
             form.addItem(item1);
             form.addItem(item2);
-
-            ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
-            );
 
             ApplicationItem updatedItem1 = new ApplicationItem(
                     itemId1,

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -94,21 +94,6 @@ class ApplicationFormTest {
         }
 
         @Test
-        void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
-            // given
-            Writer updater = new Writer(2L);
-            ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    updater, "큐시즘 28기", 2024, Semester.SECOND_HALF
-            );
-
-            // when then
-            assertThatThrownBy(() -> form.update(updated))
-                    .isInstanceOf(BusinessException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
-        }
-
-        @Test
         void 없는_지원_항목은_수정할_수_없다() {
             // given
             ApplicationForm updated = ApplicationForm.createEmptyForm(

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -154,4 +154,40 @@ class ApplicationFormTest {
         }
 
     }
+
+    @DisplayName("지원서의 작성 상태는")
+    @Nested
+    class ChangeTest {
+
+        private final ApplicationForm form = ApplicationForm.createEmptyForm(
+                new Writer(1L), new Recruiter("큐시즘"), new ApplicationYear(2023), Semester.FIRST_HALF
+        );
+
+        @Test
+        void 처음엔_작성_중_상태이다() {
+            // when then
+            assertThat(form.getWritingState()).isEqualTo(WritingState.ON_GOING);
+        }
+
+        @Test
+        void 작성_중이면_완료가_된다() {
+            // when
+            WritingState actual = form.changeWritingState();
+
+            // then
+            assertThat(actual).isEqualTo(WritingState.COMPLETE);
+        }
+
+        @Test
+        void 완료면_작성_중이_된다() {
+            // given
+            form.changeWritingState();
+
+            // when
+            WritingState actual = form.changeWritingState();
+
+            // then
+            assertThat(actual).isEqualTo(WritingState.ON_GOING);
+        }
+    }
 }

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -132,7 +132,7 @@ class ApplicationFormTest {
             form.update(updated);
 
             // then
-            List<ApplicationItem> actualItems = form.getApplicationItems();
+            List<ApplicationItem> actualItems = form.getApplicationItems().getValues();
             ListAssert<ApplicationItem> actualItem1 = assertThat(actualItems)
                     .filteredOn(item -> item.getId().equals(itemId1));
             ListAssert<ApplicationItem> actualItem2 = assertThat(actualItems)

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -26,11 +26,11 @@ class ApplicationFormTest {
         @ValueSource(strings = {"", " "})
         void 모집자는_공백일_수_없다(String recruiter) {
             // given
-            Long memberId = 1L;
+            Writer writer = new Writer(1L);
             Integer year = 2023;
 
             // when then
-            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(memberId, recruiter, year, Semester.FIRST_HALF))
+            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(writer, recruiter, year, Semester.FIRST_HALF))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.EMPTY_RECRUITER);
@@ -40,11 +40,11 @@ class ApplicationFormTest {
         @ValueSource(ints = {0, -1})
         void 지원년도는_자연수여야_한다(int year) {
             // given
-            Long memberId = 1L;
+            Writer writer = new Writer(1L);
             String recruiter = "큐시즘";
 
             // when then
-            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(memberId, recruiter, year, Semester.FIRST_HALF))
+            assertThatThrownBy(() -> ApplicationForm.createEmptyForm(writer, recruiter, year, Semester.FIRST_HALF))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.INVALID_YEAR);
@@ -55,12 +55,12 @@ class ApplicationFormTest {
     @Nested
     class UpdateFormTest {
 
-        private final Long writerId = 1L;
+        private final Writer writer = new Writer(1L);
         private final Long itemId1 = 1L;
         private final Long itemId2 = 2L;
 
         private final ApplicationForm form = ApplicationForm.createEmptyForm(
-                writerId, "큐시즘", 2023, Semester.FIRST_HALF
+                writer, "큐시즘", 2023, Semester.FIRST_HALF
         );
 
         private final ApplicationItem item1 = new ApplicationItem(
@@ -78,7 +78,7 @@ class ApplicationFormTest {
         void 로그인_회원이_지원서_작성자면_수정_가능하다() {
             // given
             ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writerId, "큐시즘 28기", 2024, Semester.SECOND_HALF
+                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
             );
 
             // when
@@ -96,8 +96,9 @@ class ApplicationFormTest {
         @Test
         void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
             // given
+            Writer updater = new Writer(2L);
             ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    2L, "큐시즘 28기", 2024, Semester.SECOND_HALF
+                    updater, "큐시즘 28기", 2024, Semester.SECOND_HALF
             );
 
             // when then
@@ -111,7 +112,7 @@ class ApplicationFormTest {
         void 없는_지원_항목은_수정할_수_없다() {
             // given
             ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writerId, "큐시즘 28기", 2024, Semester.SECOND_HALF
+                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
             );
             form.addItem(item1);
             updated.addItem(item2);
@@ -130,7 +131,7 @@ class ApplicationFormTest {
             form.addItem(item2);
 
             ApplicationForm updated = ApplicationForm.createEmptyForm(
-                    writerId, "큐시즘 28기", 2024, Semester.SECOND_HALF
+                    writer, "큐시즘 28기", 2024, Semester.SECOND_HALF
             );
 
             ApplicationItem updatedItem1 = new ApplicationItem(

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/ApplicationFormTest.java
@@ -166,16 +166,16 @@ class ApplicationFormTest {
         @Test
         void 처음엔_작성_중_상태이다() {
             // when then
-            assertThat(form.getWritingState()).isEqualTo(WritingState.ON_GOING);
+            assertThat(form.isCompleted()).isFalse();
         }
 
         @Test
         void 작성_중이면_완료가_된다() {
             // when
-            WritingState actual = form.changeWritingState();
+            form.changeWritingState();
 
             // then
-            assertThat(actual).isEqualTo(WritingState.COMPLETE);
+            assertThat(form.isCompleted()).isTrue();
         }
 
         @Test
@@ -184,10 +184,10 @@ class ApplicationFormTest {
             form.changeWritingState();
 
             // when
-            WritingState actual = form.changeWritingState();
+            form.changeWritingState();
 
             // then
-            assertThat(actual).isEqualTo(WritingState.ON_GOING);
+            assertThat(form.isCompleted()).isFalse();
         }
     }
 }

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationQuestionTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationQuestionTest.java
@@ -1,4 +1,4 @@
-package com.kusitms.wannafly.applicationform.command.domain;
+package com.kusitms.wannafly.applicationform.command.domain.value;
 
 import com.kusitms.wannafly.exception.BusinessException;
 import com.kusitms.wannafly.exception.ErrorCode;

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationYearTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/ApplicationYearTest.java
@@ -1,0 +1,21 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplicationYearTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void 지원년도는_자연수여야_한다(int value) {
+        // when then
+        assertThatThrownBy(() -> new ApplicationYear(value))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_YEAR);
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/RecruiterTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/RecruiterTest.java
@@ -1,0 +1,21 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecruiterTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void 모집자는_공백일_수_없다(String value) {
+        // when then
+        assertThatThrownBy(() -> new Recruiter(value))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EMPTY_RECRUITER);
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/WritingStateTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/domain/value/WritingStateTest.java
@@ -1,0 +1,39 @@
+package com.kusitms.wannafly.applicationform.command.domain.value;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WritingStateTest {
+
+    @DisplayName("작성 상태를 변경할 때")
+    @Nested
+    class ChangeTest {
+
+        @Test
+        void 작성_중이면_완료가_된다() {
+            // given
+            WritingState state = WritingState.ON_GOING;
+
+            // when
+            WritingState actual = state.change();
+
+            // then
+            assertThat(actual).isEqualTo(WritingState.COMPLETE);
+        }
+
+        @Test
+        void 완료면_작성_중이_된다() {
+            // given
+            WritingState state = WritingState.COMPLETE;
+
+            // when
+            WritingState actual = state.change();
+
+            // then
+            assertThat(actual).isEqualTo(WritingState.ON_GOING);
+        }
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
@@ -16,8 +16,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -109,6 +108,21 @@ public class ApplicationFormControllerTest extends ControllerTest {
                                 fieldWithPath("applicationQuestion").type(JsonFieldType.STRING).description("지원 문항"),
                                 fieldWithPath("applicationAnswer").type(JsonFieldType.STRING).description("지원 답변")
                         )
+                ));
+    }
+
+    @Test
+    void 지원서를_삭제한다() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/application-forms/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+        // then
+        result.andExpect(status().isNoContent())
+
+                .andDo(document("delete-application-form", HOST_INFO,
+                        preprocessResponse(prettyPrint())
                 ));
     }
 }

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
@@ -8,8 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_CREATE_REQUEST;
-import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_UPDATE_REQUEST;
+import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -84,6 +83,31 @@ public class ApplicationFormControllerTest extends ControllerTest {
                                         .type(JsonFieldType.STRING).description("지원 문항"),
                                 fieldWithPath("applicationItems[].applicationAnswer")
                                         .type(JsonFieldType.STRING).description("지원 답변")
+                        )
+                ));
+    }
+
+    @Test
+    void 지원_항목을_추가한다() throws Exception {
+        // given
+        given(applicationFormService.addItem(any(), any(), any()))
+                .willReturn(4L);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/application-forms/1/items")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .content(objectMapper.writeValueAsString(ITEM_CREATE_REQUEST)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/application-items/4"))
+
+                .andDo(document("add-application-item", HOST_INFO,
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("applicationQuestion").type(JsonFieldType.STRING).description("지원 문항"),
+                                fieldWithPath("applicationAnswer").type(JsonFieldType.STRING).description("지원 답변")
                         )
                 ));
     }

--- a/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/applicationform/command/presentation/ApplicationFormControllerTest.java
@@ -1,5 +1,6 @@
 package com.kusitms.wannafly.applicationform.command.presentation;
 
+import com.kusitms.wannafly.applicationform.command.dto.FormStateResponse;
 import com.kusitms.wannafly.support.ControllerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,8 +15,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -123,6 +123,28 @@ public class ApplicationFormControllerTest extends ControllerTest {
 
                 .andDo(document("delete-application-form", HOST_INFO,
                         preprocessResponse(prettyPrint())
+                ));
+    }
+
+    @Test
+    void 지원서_상태를_변경한다() throws Exception {
+        // given
+        given(applicationFormService.changeState(any(), any()))
+                .willReturn(new FormStateResponse(true));
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/api/application-forms/1/state")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+        // then
+        result.andExpect(status().isOk())
+
+                .andDo(document("application-form-state", HOST_INFO,
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("isCompleted").type(JsonFieldType.BOOLEAN).description("지원서 작성 완료 여부")
+                        )
                 ));
     }
 }

--- a/src/test/java/com/kusitms/wannafly/support/fixture/ApplicationFormFixture.java
+++ b/src/test/java/com/kusitms/wannafly/support/fixture/ApplicationFormFixture.java
@@ -9,21 +9,15 @@ import java.util.List;
 
 public class ApplicationFormFixture {
 
+    public static final ApplicationItemCreateRequest ITEM_CREATE_REQUEST = new ApplicationItemCreateRequest(
+            ApplicationFormFixture.QUESTION1, ApplicationFormFixture.ANSWER1
+    );
+
     public static final ApplicationFormCreateRequest FORM_CREATE_REQUEST = new ApplicationFormCreateRequest(
             "큐시즘",
             2023,
             "first_half",
-            List.of(
-                    new ApplicationItemCreateRequest(
-                            ApplicationFormFixture.QUESTION1, ApplicationFormFixture.ANSWER1
-                    ),
-                    new ApplicationItemCreateRequest(
-                            ApplicationFormFixture.QUESTION1, ApplicationFormFixture.ANSWER1
-                    ),
-                    new ApplicationItemCreateRequest(
-                            ApplicationFormFixture.QUESTION1, ApplicationFormFixture.ANSWER1
-                    )
-            )
+            List.of(ITEM_CREATE_REQUEST, ITEM_CREATE_REQUEST, ITEM_CREATE_REQUEST)
     );
 
     public static final ApplicationFormUpdateRequest FORM_UPDATE_REQUEST = new ApplicationFormUpdateRequest(


### PR DESCRIPTION
## 📌 작업 내용
- 지원 항목 추가 api 구현
- 지원서 삭제 api 구현
- 지원서 작성 상태 변경 api 구현

## 📝 리뷰 요청
- 앞의 PR과 똑같습니다! 가독성과 모르는 것 위주로 피드백 남겨주세요!

## 💌 참고 사항
<img width="244" alt="image" src="https://github.com/kusitms-wannafly/wannafly_be/assets/78652144/f927771b-bb05-443f-9d18-638e9daae37e">

- 이번에 기능도 구현했지만 리팩터링도 같이 진행했는데요. ApplicationForm 내부 필드들에 적극적으로 값 객체를 도입했습니다. 값 객체 도입 전과 후가 어떻게 다르고, 값 객체는 무엇인지 한 번 알아보면 좋을 것 같네요!
- 테스트가 80개가 되었네요 테스트 짜는 시간이 기능 구현 시간 보다 많은데 그래도 테스트 다 돌아가는 거 보면 마음이 편안합니다
