### PR TITLE
feat: 맞춤법 검사 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -90,3 +90,14 @@ include::{snippets}/get-one-application-folders/http-request.adoc[]
 include::{snippets}/get-one-application-folders/http-response.adoc[]
 === Response 필드
 include::{snippets}/get-one-application-folders/response-fields.adoc[]
+
+= 맞춤법 검사
+== 지원서 보관함 생성
+=== Request
+include::{snippets}/grammar-check/http-request.adoc[]
+=== Request 필드
+include::{snippets}/grammar-check/request-fields.adoc[]
+=== Response
+include::{snippets}/grammar-check/http-response.adoc[]
+=== Response 필드
+include::{snippets}/grammar-check/response-fields.adoc[]

--- a/src/main/java/com/kusitms/wannafly/command/grammar/application/GrammarService.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/application/GrammarService.java
@@ -1,0 +1,9 @@
+package com.kusitms.wannafly.command.grammar.application;
+
+import com.kusitms.wannafly.command.grammar.dto.GrammarRequest;
+import com.kusitms.wannafly.command.grammar.dto.GrammarResponse;
+
+public interface GrammarService {
+
+    GrammarResponse check(GrammarRequest request);
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/dto/GrammarRequest.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/dto/GrammarRequest.java
@@ -1,0 +1,4 @@
+package com.kusitms.wannafly.command.grammar.dto;
+
+public record GrammarRequest(String content) {
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/dto/GrammarResponse.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/dto/GrammarResponse.java
@@ -1,0 +1,4 @@
+package com.kusitms.wannafly.command.grammar.dto;
+
+public record GrammarResponse(String content) {
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarClient.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarClient.java
@@ -1,0 +1,12 @@
+package com.kusitms.wannafly.command.grammar.infrastructure;
+
+import com.kusitms.wannafly.command.grammar.dto.GrammarRequest;
+import com.kusitms.wannafly.command.grammar.dto.GrammarResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface GrammarClient {
+
+    @PostExchange("/wannafly/grammers-check")
+    GrammarResponse check(@RequestBody GrammarRequest request);
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarClientConfig.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarClientConfig.java
@@ -1,0 +1,26 @@
+package com.kusitms.wannafly.command.grammar.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class GrammarClientConfig {
+
+    @Value("${grammar.origin}")
+    private String grammarOrigin;
+
+    @Bean
+    public GrammarClient grammarClient() {
+        WebClient client = WebClient.builder()
+                .baseUrl(grammarOrigin)
+                .build();
+        return HttpServiceProxyFactory
+                .builder(WebClientAdapter.forClient(client))
+                .build()
+                .createClient(GrammarClient.class);
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarServiceImpl.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/infrastructure/GrammarServiceImpl.java
@@ -1,0 +1,19 @@
+package com.kusitms.wannafly.command.grammar.infrastructure;
+
+import com.kusitms.wannafly.command.grammar.application.GrammarService;
+import com.kusitms.wannafly.command.grammar.dto.GrammarRequest;
+import com.kusitms.wannafly.command.grammar.dto.GrammarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GrammarServiceImpl implements GrammarService {
+
+    private final GrammarClient grammarClient;
+
+    @Override
+    public GrammarResponse check(GrammarRequest request) {
+        return grammarClient.check(request);
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/command/grammar/presentation/GrammarController.java
+++ b/src/main/java/com/kusitms/wannafly/command/grammar/presentation/GrammarController.java
@@ -1,0 +1,22 @@
+package com.kusitms.wannafly.command.grammar.presentation;
+
+import com.kusitms.wannafly.command.grammar.application.GrammarService;
+import com.kusitms.wannafly.command.grammar.dto.GrammarRequest;
+import com.kusitms.wannafly.command.grammar.dto.GrammarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GrammarController {
+
+    private final GrammarService grammarService;
+
+    @PostMapping("/api/grammar/check")
+    public ResponseEntity<GrammarResponse> check(@RequestBody GrammarRequest request) {
+        return ResponseEntity.ok(grammarService.check(request));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,6 +55,8 @@ cors:
   allowed:
     origins: http://localhost:3000
 
+grammar:
+  origin: https://fake-origin.com
 
 logging:
   level:

--- a/src/test/java/com/kusitms/wannafly/Acceptance/AcceptanceTest.java
+++ b/src/test/java/com/kusitms/wannafly/Acceptance/AcceptanceTest.java
@@ -1,11 +1,13 @@
 package com.kusitms.wannafly.Acceptance;
 
+import com.kusitms.wannafly.command.grammar.application.GrammarService;
 import com.kusitms.wannafly.support.isolation.WannaflyTestIsolationExtension;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -19,4 +21,7 @@ class AcceptanceTest {
     void setUp() {
         RestAssured.port = port;
     }
+
+    @MockBean
+    private GrammarService grammarService;
 }

--- a/src/test/java/com/kusitms/wannafly/WannaflyApplicationTests.java
+++ b/src/test/java/com/kusitms/wannafly/WannaflyApplicationTests.java
@@ -1,13 +1,11 @@
 package com.kusitms.wannafly;
 
-import com.kusitms.wannafly.support.isolation.WannaflyTestIsolationExtension;
+import com.kusitms.wannafly.support.ServiceTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@ExtendWith(WannaflyTestIsolationExtension.class)
-class WannaflyApplicationTests {
+class WannaflyApplicationTests extends ServiceTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/kusitms/wannafly/command/auth/token/JwtTokenProviderTest.java
+++ b/src/test/java/com/kusitms/wannafly/command/auth/token/JwtTokenProviderTest.java
@@ -1,15 +1,14 @@
 package com.kusitms.wannafly.command.auth.token;
 
+import com.kusitms.wannafly.support.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-class JwtTokenProviderTest {
+class JwtTokenProviderTest extends ServiceTest {
 
     @Autowired
     private JwtTokenProvider tokenProvider;

--- a/src/test/java/com/kusitms/wannafly/command/grammar/presentation/GrammarControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/command/grammar/presentation/GrammarControllerTest.java
@@ -1,0 +1,57 @@
+package com.kusitms.wannafly.command.grammar.presentation;
+
+import com.kusitms.wannafly.command.grammar.dto.GrammarRequest;
+import com.kusitms.wannafly.command.grammar.dto.GrammarResponse;
+import com.kusitms.wannafly.support.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GrammarControllerTest extends ControllerTest {
+
+    private String accessToken;
+
+    @BeforeEach
+    void setToken() {
+        accessToken = loginAndGetAccessToken(1L);
+    }
+
+    @Test
+    void 문법을_체크한() throws Exception {
+        // given
+        BDDMockito.given(grammarService.check(any()))
+                .willReturn(new GrammarResponse("왜 안 돼"));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/grammar/check")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GrammarRequest("외않되")))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken));
+
+        // then
+        result.andExpect(status().isOk())
+
+                .andDo(document("grammar-check", HOST_INFO,
+                        preprocessResponse(prettyPrint()),
+
+                        requestFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("검사 전 텍스트")
+                        ),
+                        responseFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("검사 후 텍스트")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
@@ -1,6 +1,8 @@
 package com.kusitms.wannafly.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.wannafly.command.grammar.application.GrammarService;
+import com.kusitms.wannafly.command.grammar.presentation.GrammarController;
 import com.kusitms.wannafly.query.service.ApplicationFolderQueryService;
 import com.kusitms.wannafly.command.applicationfolder.presentation.ApplicationFolderController;
 import com.kusitms.wannafly.query.controller.ApplicationFolderQueryController;
@@ -33,7 +35,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
         ApplicationFormController.class,
         ApplicationFormQueryController.class,
         ApplicationFolderController.class,
-        ApplicationFolderQueryController.class
+        ApplicationFolderQueryController.class,
+        GrammarController.class
 })
 @Import({
         ControllerTestSecurityConfig.class,
@@ -73,6 +76,9 @@ public class ControllerTest {
 
     @MockBean
     protected ApplicationFolderQueryService applicationFolderQueryService;
+
+    @MockBean
+    protected GrammarService grammarService;
 
     protected String loginAndGetAccessToken(Long memberId) {
         given(authService.authorize(any()))

--- a/src/test/java/com/kusitms/wannafly/support/ServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/support/ServiceTest.java
@@ -1,10 +1,15 @@
 package com.kusitms.wannafly.support;
 
+import com.kusitms.wannafly.command.grammar.application.GrammarService;
 import com.kusitms.wannafly.support.isolation.WannaflyTestIsolationExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @ExtendWith(WannaflyTestIsolationExtension.class)
 public class ServiceTest {
+
+    @MockBean
+    private GrammarService grammarService;
 }


### PR DESCRIPTION
## 📌 작업 내용
- AWS Lambda로 요청해 맞춤법 검사를 연결하는 API 구현

## 📝 리뷰 요청
- 코드 변화가 많이는 없어서 모르는 거 위주로 질문해주세요!

## 💌 참고 사항
- 외부에 http 요청을 날리기 위해 [Http interface ](https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface)사용
- be-config의 prod, dev.yml에 람다 origin 추가해놨음