### PR TITLE
hotfix: 지원 항목 추가 api 동시적 요청시 발생하는 데드락 해결

### DIFF
--- a/src/main/java/com/kusitms/wannafly/command/applicationform/application/ApplicationFormService.java
+++ b/src/main/java/com/kusitms/wannafly/command/applicationform/application/ApplicationFormService.java
@@ -2,11 +2,11 @@ package com.kusitms.wannafly.command.applicationform.application;
 
 import com.kusitms.wannafly.command.applicationform.domain.ApplicationForm;
 import com.kusitms.wannafly.command.applicationform.domain.ApplicationFormRepository;
-import com.kusitms.wannafly.command.applicationform.domain.ApplicationItem;
-import com.kusitms.wannafly.command.applicationform.domain.value.ApplicationAnswer;
-import com.kusitms.wannafly.command.applicationform.domain.value.ApplicationQuestion;
 import com.kusitms.wannafly.command.applicationform.domain.value.Writer;
-import com.kusitms.wannafly.command.applicationform.dto.*;
+import com.kusitms.wannafly.command.applicationform.dto.ApplicationFormCreateRequest;
+import com.kusitms.wannafly.command.applicationform.dto.ApplicationFormMapper;
+import com.kusitms.wannafly.command.applicationform.dto.ApplicationFormUpdateRequest;
+import com.kusitms.wannafly.command.applicationform.dto.FormStateRequest;
 import com.kusitms.wannafly.command.auth.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,19 +34,6 @@ public class ApplicationFormService {
         ApplicationForm originalForm = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
         ApplicationForm updatedForm = ApplicationFormMapper.toDomain(request, writer);
         originalForm.update(updatedForm);
-    }
-
-    public Long addItem(Long applicationFormId,
-                        LoginMember loginMember,
-                        ApplicationItemCreateRequest request) {
-        Writer writer = new Writer(loginMember.id());
-        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
-        ApplicationItem item = form.addItem(
-                new ApplicationQuestion(request.applicationQuestion()),
-                new ApplicationAnswer(request.applicationAnswer())
-        );
-        applicationFormRepository.flush();
-        return item.getId();
     }
 
     public void deleteForm(Long applicationFormId, LoginMember loginMember) {

--- a/src/main/java/com/kusitms/wannafly/command/applicationform/application/ApplicationItemService.java
+++ b/src/main/java/com/kusitms/wannafly/command/applicationform/application/ApplicationItemService.java
@@ -1,0 +1,37 @@
+package com.kusitms.wannafly.command.applicationform.application;
+
+import com.kusitms.wannafly.command.applicationform.domain.ApplicationForm;
+import com.kusitms.wannafly.command.applicationform.domain.ApplicationItem;
+import com.kusitms.wannafly.command.applicationform.domain.ApplicationItemRepository;
+import com.kusitms.wannafly.command.applicationform.domain.value.ApplicationAnswer;
+import com.kusitms.wannafly.command.applicationform.domain.value.ApplicationQuestion;
+import com.kusitms.wannafly.command.applicationform.domain.value.Writer;
+import com.kusitms.wannafly.command.applicationform.dto.ApplicationItemCreateRequest;
+import com.kusitms.wannafly.command.auth.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ApplicationItemService {
+
+    private final ApplicationItemRepository applicationItemRepository;
+    private final WriterCheckedFormService writerCheckedFormService;
+
+
+    public Long addItem(Long applicationFormId,
+                        LoginMember loginMember,
+                        ApplicationItemCreateRequest request) {
+        Writer writer = new Writer(loginMember.id());
+        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
+        ApplicationItem item = new ApplicationItem(
+                form,
+                new ApplicationQuestion(request.applicationQuestion()),
+                new ApplicationAnswer(request.applicationAnswer())
+        );
+        applicationItemRepository.save(item);
+        return item.getId();
+    }
+}

--- a/src/main/java/com/kusitms/wannafly/command/applicationform/domain/ApplicationForm.java
+++ b/src/main/java/com/kusitms/wannafly/command/applicationform/domain/ApplicationForm.java
@@ -61,18 +61,17 @@ public class ApplicationForm {
         updateModifiedDate();
     }
 
-    public ApplicationItem addItem(ApplicationQuestion question, ApplicationAnswer answer) {
-        ApplicationItem item = new ApplicationItem(this, question, answer);
-        applicationItems.addItem(item);
-        updateModifiedDate();
-        return item;
-    }
-
     public void update(ApplicationForm updatedForm) {
         recruiter = updatedForm.getRecruiter();
         year = updatedForm.getYear();
         semester = updatedForm.getSemester();
         applicationItems.updateItems(updatedForm.getApplicationItems());
+        updateModifiedDate();
+    }
+
+    public void addItem(ApplicationQuestion question, ApplicationAnswer answer) {
+        ApplicationItem item = new ApplicationItem(this, question, answer);
+        applicationItems.addItem(item);
         updateModifiedDate();
     }
 

--- a/src/main/java/com/kusitms/wannafly/command/applicationform/domain/ApplicationItemRepository.java
+++ b/src/main/java/com/kusitms/wannafly/command/applicationform/domain/ApplicationItemRepository.java
@@ -1,0 +1,6 @@
+package com.kusitms.wannafly.command.applicationform.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationItemRepository extends JpaRepository<ApplicationItem, Long> {
+}

--- a/src/main/java/com/kusitms/wannafly/command/applicationform/presentation/ApplicationFormController.java
+++ b/src/main/java/com/kusitms/wannafly/command/applicationform/presentation/ApplicationFormController.java
@@ -1,6 +1,7 @@
 package com.kusitms.wannafly.command.applicationform.presentation;
 
 import com.kusitms.wannafly.command.applicationform.application.ApplicationFormService;
+import com.kusitms.wannafly.command.applicationform.application.ApplicationItemService;
 import com.kusitms.wannafly.command.applicationform.dto.ApplicationFormCreateRequest;
 import com.kusitms.wannafly.command.applicationform.dto.ApplicationFormUpdateRequest;
 import com.kusitms.wannafly.command.applicationform.dto.ApplicationItemCreateRequest;
@@ -18,6 +19,7 @@ import java.net.URI;
 public class ApplicationFormController {
 
     private final ApplicationFormService applicationFormService;
+    private final ApplicationItemService applicationItemService;
 
     @PostMapping
     public ResponseEntity<Void> createForm(@RequestBody ApplicationFormCreateRequest request,
@@ -39,7 +41,7 @@ public class ApplicationFormController {
     public ResponseEntity<Void> addItem(@PathVariable Long applicationFormId,
                                         @RequestBody ApplicationItemCreateRequest request,
                                         LoginMember loginMember) {
-        Long itemId = applicationFormService.addItem(applicationFormId, loginMember, request);
+        Long itemId = applicationItemService.addItem(applicationFormId, loginMember, request);
         return ResponseEntity.created(URI.create("/application-items/" + itemId))
                 .build();
     }

--- a/src/test/java/com/kusitms/wannafly/command/applicationform/application/ApplicationFormServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/command/applicationform/application/ApplicationFormServiceTest.java
@@ -102,42 +102,6 @@ class ApplicationFormServiceTest extends ServiceTest {
         }
     }
 
-    @DisplayName("지원서의 지원 항목을 추가할 때")
-    @Nested
-    class AddItemTest {
-
-        @Test
-        void 로그인_회원이_지원서_작성자면_추가_가능하다() {
-            // given
-            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
-
-            // when
-            Long itemId = applicationFormService.addItem(formId, loginMember, ITEM_CREATE_REQUEST);
-
-            // then
-            ApplicationFormResponse form = applicationFormQueryService.findOne(formId, loginMember);
-            assertAll(
-                    () -> assertThat(itemId).isEqualTo(4),
-                    () -> assertThat(form.applicationItems()).hasSize(4)
-            );
-        }
-
-        @Test
-        void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
-            // given
-            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
-
-            // when then
-            LoginMember requester = new LoginMember(2L);
-            assertThatThrownBy(() -> applicationFormService.addItem(
-                    formId, requester, ITEM_CREATE_REQUEST)
-            )
-                    .isInstanceOf(BusinessException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
-        }
-    }
-
     @DisplayName("지원서를 삭제할 때")
     @Nested
     class DeleteTest {

--- a/src/test/java/com/kusitms/wannafly/command/applicationform/application/ApplicationItemServiceTest.java
+++ b/src/test/java/com/kusitms/wannafly/command/applicationform/application/ApplicationItemServiceTest.java
@@ -1,0 +1,69 @@
+package com.kusitms.wannafly.command.applicationform.application;
+
+import com.kusitms.wannafly.command.auth.LoginMember;
+import com.kusitms.wannafly.exception.BusinessException;
+import com.kusitms.wannafly.exception.ErrorCode;
+import com.kusitms.wannafly.query.dto.ApplicationFormResponse;
+import com.kusitms.wannafly.query.service.ApplicationFormQueryService;
+import com.kusitms.wannafly.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.FORM_CREATE_REQUEST;
+import static com.kusitms.wannafly.support.fixture.ApplicationFormFixture.ITEM_CREATE_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ApplicationItemServiceTest extends ServiceTest {
+
+    @Autowired
+    private ApplicationItemService applicationItemService;
+
+    @Autowired
+    private ApplicationFormService applicationFormService;
+
+    @Autowired
+    private ApplicationFormQueryService applicationFormQueryService;
+
+    private final LoginMember loginMember = new LoginMember(1L);
+
+    @DisplayName("지원서의 지원 항목을 추가할 때")
+    @Nested
+    class AddItemTest {
+
+        @Test
+        void 로그인_회원이_지원서_작성자면_추가_가능하다() {
+            // given
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+
+            // when
+            Long itemId = applicationItemService.addItem(formId, loginMember, ITEM_CREATE_REQUEST);
+
+            // then
+            ApplicationFormResponse form = applicationFormQueryService.findOne(formId, loginMember);
+            assertAll(
+                    () -> assertThat(itemId).isEqualTo(4),
+                    () -> assertThat(form.applicationItems()).hasSize(4)
+            );
+        }
+
+        @Test
+        void 로그인_회원이_지원서_작성자가_아니면_예외가_발생한다() {
+            // given
+            Long formId = applicationFormService.createForm(loginMember, FORM_CREATE_REQUEST);
+
+            // when then
+            LoginMember requester = new LoginMember(2L);
+            assertThatThrownBy(() -> applicationItemService.addItem(
+                    formId, requester, ITEM_CREATE_REQUEST)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_WRITER_OF_FORM);
+        }
+    }
+
+}

--- a/src/test/java/com/kusitms/wannafly/command/applicationform/presentation/ApplicationFormControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/command/applicationform/presentation/ApplicationFormControllerTest.java
@@ -90,7 +90,7 @@ public class ApplicationFormControllerTest extends ControllerTest {
     @Test
     void 지원_항목을_추가한다() throws Exception {
         // given
-        given(applicationFormService.addItem(any(), any(), any()))
+        given(applicationItemService.addItem(any(), any(), any()))
                 .willReturn(4L);
 
         // when

--- a/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
+++ b/src/test/java/com/kusitms/wannafly/support/ControllerTest.java
@@ -1,6 +1,7 @@
 package com.kusitms.wannafly.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.wannafly.command.applicationform.application.ApplicationItemService;
 import com.kusitms.wannafly.command.grammar.application.GrammarService;
 import com.kusitms.wannafly.command.grammar.presentation.GrammarController;
 import com.kusitms.wannafly.query.service.ApplicationFolderQueryService;
@@ -73,6 +74,9 @@ public class ControllerTest {
 
     @MockBean
     protected ApplicationFolderService applicationFolderService;
+
+    @MockBean
+    protected ApplicationItemService applicationItemService;
 
     @MockBean
     protected ApplicationFolderQueryService applicationFolderQueryService;


### PR DESCRIPTION
#25

## 📌 작업 내용
- 기존의 Cascade.Persist와 변경감지를 이용해 지원서에 지원 항목을 추가하던 것을 직접 repository에 save하도록 변경

변경 전
``` java
        Writer writer = new Writer(loginMember.id());
        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
        ApplicationItem item = form.addItem(
                new ApplicationQuestion(request.applicationQuestion()),
                new ApplicationAnswer(request.applicationAnswer())
        );
        applicationFormRepository.flush();
        return item.getId();
```

변경 후
``` java
        Writer writer = new Writer(loginMember.id());
        ApplicationForm form = writerCheckedFormService.checkWriterAndGet(applicationFormId, writer);
        ApplicationItem item = new ApplicationItem(
                form,
                new ApplicationQuestion(request.applicationQuestion()),
                new ApplicationAnswer(request.applicationAnswer())
        );
        applicationItemRepository.save(item);
        return item.getId();
```
